### PR TITLE
Add MiniMax text-to-image provider using native image_generation endpoint

### DIFF
--- a/client/electron/services/aiService.cjs
+++ b/client/electron/services/aiService.cjs
@@ -61,6 +61,25 @@ const OPENAI_IMAGE_PROVIDER_META = {
   },
 };
 
+// MiniMax 生图使用独立的 /image_generation 接口，请求字段与响应结构均不同于 OpenAI 兼容协议。
+const MINIMAX_IMAGE_PROVIDER_META = {
+  label: 'MiniMax',
+  defaultBaseUrl: 'https://api.minimaxi.com/v1',
+  logProvider: 'minimax',
+  modelLabel: '生图模型名称',
+};
+
+// 图片尺寸枚举到 MiniMax 官方 aspect_ratio 的映射；'auto' 不下发比例，交由服务端默认处理。
+const MINIMAX_IMAGE_ASPECT_RATIOS = {
+  '1024x1024': '1:1',
+  '2048x2048': '1:1',
+  '1536x1024': '3:2',
+  '1024x1536': '2:3',
+  '2048x1152': '16:9',
+  '3840x2160': '16:9',
+  '2160x3840': '9:16',
+};
+
 function trimBaseUrl(baseUrl) {
   return String(baseUrl || '').trim().replace(/\/+$/, '');
 }
@@ -1699,6 +1718,287 @@ async function generateGoogleImage(app, config, request) {
   }
 }
 
+function normalizeMiniMaxAspectRatio(imageConfig, requestSize) {
+  const size = String(requestSize || imageConfig?.image_size || '').trim();
+  if (!size || size === 'auto') {
+    return '';
+  }
+  return MINIMAX_IMAGE_ASPECT_RATIOS[size] || '1:1';
+}
+
+function createMiniMaxImageRequestBody(imageConfig, prompt, requestSize) {
+  const body = {
+    model: imageConfig.model_name,
+    prompt,
+    response_format: 'url',
+    n: 1,
+    prompt_optimizer: true,
+  };
+  const aspectRatio = normalizeMiniMaxAspectRatio(imageConfig, requestSize);
+  if (aspectRatio) {
+    body.aspect_ratio = aspectRatio;
+  }
+  return body;
+}
+
+function safeMiniMaxImageResponse(data) {
+  const payload = data && typeof data === 'object' ? data.data : null;
+  if (!payload || typeof payload !== 'object') {
+    return data;
+  }
+  return {
+    ...data,
+    data: {
+      ...payload,
+      image_base64: Array.isArray(payload.image_base64) ? '[base64 omitted]' : payload.image_base64,
+    },
+  };
+}
+
+function getMiniMaxImageStatusError(responseData, fallbackMessage) {
+  const baseResp = responseData?.base_resp || {};
+  const code = Number(baseResp.status_code);
+  if (Number.isFinite(code) && code !== 0) {
+    return baseResp.status_msg || fallbackMessage;
+  }
+  return '';
+}
+
+function extractMiniMaxImageUrls(responseData) {
+  const list = responseData?.data?.image_urls;
+  return Array.isArray(list) ? list.filter((url) => typeof url === 'string' && url) : [];
+}
+
+function extractMiniMaxImageBase64(responseData) {
+  const list = responseData?.data?.image_base64;
+  return Array.isArray(list) ? list.filter((item) => typeof item === 'string' && item) : [];
+}
+
+function getMiniMaxImageFailureMessage(responseData, fallbackMessage) {
+  return getMiniMaxImageStatusError(responseData, '') || fallbackMessage;
+}
+
+async function requestMiniMaxImageData(baseUrl, apiKey, requestBody, fallbackMessage, options = {}) {
+  let response = null;
+  try {
+    response = await fetch(`${baseUrl}/image_generation`, {
+      method: 'POST',
+      headers: createHeaders(apiKey),
+      body: JSON.stringify(requestBody),
+      signal: options.signal,
+    });
+  } catch (error) {
+    throw markAiRequestError(error, { retryable: true });
+  }
+  await ensureOk(response, fallbackMessage, { source: options.source || 'minimax-image-model' });
+  try {
+    return await response.json();
+  } catch (error) {
+    throw markAiRequestError(error, { retryable: true });
+  }
+}
+
+async function createImageFromMiniMaxResponse(responseData) {
+  const urls = extractMiniMaxImageUrls(responseData);
+  if (urls.length) {
+    return downloadImage(urls[0]);
+  }
+
+  const base64List = extractMiniMaxImageBase64(responseData);
+  if (base64List.length) {
+    return {
+      buffer: Buffer.from(base64List[0], 'base64'),
+      mime_type: 'image/png',
+    };
+  }
+
+  return null;
+}
+
+async function testMiniMaxImageModel(app, config) {
+  const imageConfig = config.image_model || {};
+  const meta = MINIMAX_IMAGE_PROVIDER_META;
+  let responseData = null;
+  let analyticsTracked = false;
+
+  if (!imageConfig.api_key) {
+    throw new Error(`请先填写${meta.label} API Key`);
+  }
+
+  if (!imageConfig.model_name) {
+    throw new Error(`请先填写${meta.label}${meta.modelLabel}`);
+  }
+
+  const baseUrl = requireBaseUrl(imageConfig.base_url, `${meta.label} Base URL 缺失，请重新选择服务商后保存配置`);
+  const requestMode = normalizeImageRequestMode(imageConfig);
+  const requestId = createRequestId();
+  const logTitle = `AI生图测试-${meta.label}`;
+  const requestBody = createMiniMaxImageRequestBody(imageConfig, '大字报，内容是“易标AI老好了”');
+
+  try {
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: 'image-test-pending',
+      provider: meta.logProvider,
+      request_mode: requestMode,
+      url: `${baseUrl}/image_generation`,
+      request: requestBody,
+      status: 'pending',
+      created_at: new Date().toISOString(),
+    });
+    responseData = await runWithAiRetry(() => runWithOperationTimeout(
+      (signal) => requestMiniMaxImageData(
+        baseUrl,
+        imageConfig.api_key,
+        requestBody,
+        `${meta.label}生图测试失败`,
+        { signal },
+      ),
+      AI_REQUEST_TIMEOUT_MS,
+    ));
+
+    trackAiRequest(app, config, { ai_request_type: 'image' });
+    analyticsTracked = true;
+
+    const statusError = getMiniMaxImageStatusError(responseData, `${meta.label}生图测试失败`);
+    if (statusError) {
+      throw createAiResponseDataError(statusError, responseData);
+    }
+
+    const imageUrl = extractMiniMaxImageUrls(responseData)[0] || '';
+    const imageData = imageUrl ? '' : (extractMiniMaxImageBase64(responseData)[0] || '');
+
+    if (!imageUrl && !imageData) {
+      throw createAiResponseDataError(getMiniMaxImageFailureMessage(responseData, `${meta.label}生图测试未返回图片数据`), responseData);
+    }
+
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: 'image-test',
+      provider: meta.logProvider,
+      request_mode: requestMode,
+      request: requestBody,
+      response: safeMiniMaxImageResponse(responseData),
+      result: {
+        image_url: imageUrl,
+        image_data: imageData ? '[base64 omitted]' : '',
+        mime_type: 'image/png',
+      },
+      created_at: new Date().toISOString(),
+    });
+
+    return {
+      success: true,
+      message: imageUrl ? `测试成功：已生成图片 ${imageUrl}` : '测试成功：已返回生图结果',
+      image_url: imageUrl,
+      image_data: imageData,
+      mime_type: 'image/png',
+    };
+  } catch (error) {
+    if (!analyticsTracked) {
+      trackAiRequest(app, config, { ai_request_type: 'image' });
+    }
+    const errorMessage = error?.name === 'AbortError' ? IMAGE_MODEL_TEST_TIMEOUT_MESSAGE : error?.message || '生图模型测试失败';
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: 'image-test-error',
+      provider: meta.logProvider,
+      request_mode: requestMode,
+      request: requestBody,
+      response: getAiErrorLogResponse(error, responseData ? safeMiniMaxImageResponse(responseData) : null),
+      error: getAiErrorLogError(error, errorMessage),
+      created_at: new Date().toISOString(),
+    });
+    const wrappedError = copyRawAiErrorResponse(error, new Error(errorMessage));
+    emitAiHttpErrorToWindows(wrappedError);
+    throw wrappedError;
+  }
+}
+
+async function generateMiniMaxImage(app, config, request) {
+  const imageConfig = config.image_model || {};
+  const meta = MINIMAX_IMAGE_PROVIDER_META;
+  const requestId = createRequestId();
+  const logTitle = resolveAiLogTitle(request, request.title ? `AI生图-${request.title}` : 'AI生图');
+  const requestMode = normalizeImageRequestMode(imageConfig);
+  const baseUrl = requireBaseUrl(imageConfig.base_url, `${meta.label} Base URL 缺失，请重新选择服务商后保存配置`);
+  const requestBody = createMiniMaxImageRequestBody(imageConfig, normalizeImagePrompt(request), request.size);
+  let responseData = null;
+  let analyticsTracked = false;
+
+  try {
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: 'image-pending',
+      provider: meta.logProvider,
+      request_mode: requestMode,
+      url: `${baseUrl}/image_generation`,
+      request: requestBody,
+      status: 'pending',
+      created_at: new Date().toISOString(),
+    });
+    responseData = await runWithAiRetry(() => runWithOperationTimeout(
+      (signal) => requestMiniMaxImageData(
+        baseUrl,
+        imageConfig.api_key,
+        requestBody,
+        `${meta.label}生图失败`,
+        { signal, source: `${meta.logProvider}-image-model` },
+      ),
+      AI_REQUEST_TIMEOUT_MS,
+    ));
+    trackAiRequest(app, config, { ai_request_type: 'image' });
+    analyticsTracked = true;
+
+    const statusError = getMiniMaxImageStatusError(responseData, `${meta.label}生图失败`);
+    if (statusError) {
+      throw createAiResponseDataError(statusError, responseData);
+    }
+
+    const image = await createImageFromMiniMaxResponse(responseData);
+    if (!image) {
+      throw createAiResponseDataError(getMiniMaxImageFailureMessage(responseData, `${meta.label}生图未返回图片数据`), responseData);
+    }
+
+    const saved = saveGeneratedImage(app, image);
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: 'image',
+      provider: meta.logProvider,
+      request_mode: requestMode,
+      request: requestBody,
+      response: safeMiniMaxImageResponse(responseData),
+      result: saved,
+      created_at: new Date().toISOString(),
+    });
+    return { success: true, title: request.title || '', ...saved };
+  } catch (error) {
+    if (!analyticsTracked) {
+      trackAiRequest(app, config, { ai_request_type: 'image' });
+      analyticsTracked = true;
+    }
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: 'image-error',
+      provider: meta.logProvider,
+      request_mode: requestMode,
+      request: requestBody,
+      response: getAiErrorLogResponse(error, responseData ? safeMiniMaxImageResponse(responseData) : null),
+      error: getAiErrorLogError(error, error.message),
+      created_at: new Date().toISOString(),
+    });
+    const finalError = markAiRequestError(error, { retryable: false });
+    emitAiHttpErrorToWindows(finalError);
+    throw finalError;
+  }
+}
+
 async function generateImageWithConfig(app, config, request) {
   const availability = getImageModelAvailability(config);
   if (!availability.available) {
@@ -1711,6 +2011,10 @@ async function generateImageWithConfig(app, config, request) {
 
   if (config.image_model?.provider === 'google-ai-studio') {
     return generateGoogleImage(app, config, request);
+  }
+
+  if (config.image_model?.provider === 'minimax') {
+    return generateMiniMaxImage(app, config, request);
   }
 
   throw new Error('当前生图服务商暂不支持正文配图');
@@ -1853,6 +2157,10 @@ function createAiService({ app, configStore }) {
         return testGoogleImageModel(app, trackedConfig);
       }
 
+      if (trackedConfig.image_model?.provider === 'minimax') {
+        return testMiniMaxImageModel(app, trackedConfig);
+      }
+
       throw new Error('当前服务商暂不支持测试');
     },
 
@@ -1967,4 +2275,12 @@ function createAiService({ app, configStore }) {
 
 module.exports = {
   createAiService,
+  __test__: {
+    createMiniMaxImageRequestBody,
+    normalizeMiniMaxAspectRatio,
+    extractMiniMaxImageUrls,
+    extractMiniMaxImageBase64,
+    getMiniMaxImageStatusError,
+    safeMiniMaxImageResponse,
+  },
 };

--- a/client/electron/services/aiService.minimaxImage.test.cjs
+++ b/client/electron/services/aiService.minimaxImage.test.cjs
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { __test__ } = require('./aiService.cjs');
+
+test('MiniMax 生图请求体使用原生字段并把尺寸枚举映射为 aspect_ratio', () => {
+  const body = __test__.createMiniMaxImageRequestBody(
+    { model_name: 'image-01', image_size: '1536x1024' },
+    '一张示意图',
+  );
+  assert.equal(body.model, 'image-01');
+  assert.equal(body.prompt, '一张示意图');
+  assert.equal(body.response_format, 'url');
+  assert.equal(body.n, 1);
+  assert.equal(body.prompt_optimizer, true);
+  assert.equal(body.aspect_ratio, '3:2');
+  assert.ok(!('size' in body));
+});
+
+test('尺寸为 auto 时不下发 aspect_ratio', () => {
+  const ratio = __test__.normalizeMiniMaxAspectRatio({ image_size: 'auto' });
+  assert.equal(ratio, '');
+  const body = __test__.createMiniMaxImageRequestBody({ model_name: 'image-01', image_size: 'auto' }, 'p');
+  assert.ok(!('aspect_ratio' in body));
+});
+
+test('从 data.image_urls 解析图片地址', () => {
+  const urls = __test__.extractMiniMaxImageUrls({
+    data: { image_urls: ['https://example.com/a.png', '', 'https://example.com/b.png'] },
+    base_resp: { status_code: 0 },
+  });
+  assert.deepEqual(urls, ['https://example.com/a.png', 'https://example.com/b.png']);
+});
+
+test('base_resp.status_code 非 0 时返回状态错误信息', () => {
+  const message = __test__.getMiniMaxImageStatusError(
+    { base_resp: { status_code: 1004, status_msg: 'invalid api key' } },
+    '生图失败',
+  );
+  assert.equal(message, 'invalid api key');
+  const ok = __test__.getMiniMaxImageStatusError({ base_resp: { status_code: 0 } }, '生图失败');
+  assert.equal(ok, '');
+});
+
+test('日志脱敏隐藏 base64 图片数据', () => {
+  const safe = __test__.safeMiniMaxImageResponse({
+    data: { image_urls: ['https://example.com/a.png'], image_base64: ['AAAA'] },
+    base_resp: { status_code: 0 },
+  });
+  assert.equal(safe.data.image_base64, '[base64 omitted]');
+  assert.deepEqual(safe.data.image_urls, ['https://example.com/a.png']);
+});

--- a/client/electron/services/configStore.cjs
+++ b/client/electron/services/configStore.cjs
@@ -9,7 +9,7 @@ const {
 
 const textModelProviders = ['jinlong', 'volcengine', 'deepseek', 'agnes', 'custom'];
 const legacyTextModelProviders = ['longcat'];
-const imageModelProviders = ['jinlong', 'volcengine', 'google-ai-studio', 'agnes', 'custom'];
+const imageModelProviders = ['jinlong', 'volcengine', 'google-ai-studio', 'agnes', 'minimax', 'custom'];
 const aiRequestModes = ['normal', 'stream'];
 const updateChannels = ['github', 'cloudflare'];
 const DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT = 400000;
@@ -151,6 +151,18 @@ const defaultImageModelProfiles = {
     model_name: '',
     image_size: '1024x1024',
     request_mode: 'stream',
+    concurrency_limit: DEFAULT_IMAGE_CONCURRENCY_LIMIT,
+    status: 'untested',
+    tested_at: '',
+    last_error: '',
+  },
+  minimax: {
+    provider: 'minimax',
+    base_url: 'https://api.minimaxi.com/v1',
+    api_key: '',
+    model_name: 'image-01',
+    image_size: '1024x1024',
+    request_mode: 'normal',
     concurrency_limit: DEFAULT_IMAGE_CONCURRENCY_LIMIT,
     status: 'untested',
     tested_at: '',
@@ -488,7 +500,7 @@ function normalizeImageModelProfile(provider, profile) {
   const useProviderDefaultImageModel = provider === 'jinlong' && !String(source.model_name ?? '').trim();
   return {
     provider,
-    base_url: provider === 'custom'
+    base_url: provider === 'custom' || provider === 'minimax'
       ? source.base_url !== undefined ? source.base_url : defaults.base_url
       : defaults.base_url,
     api_key: source.api_key !== undefined ? source.api_key : defaults.api_key,

--- a/client/src/features/settings/pages/SettingsPage.tsx
+++ b/client/src/features/settings/pages/SettingsPage.tsx
@@ -191,6 +191,7 @@ const imageProviders: Array<{ value: ImageModelProvider; label: string }> = [
   { value: 'volcengine', label: '火山方舟' },
   { value: 'google-ai-studio', label: 'Google AI Studio' },
   { value: 'agnes', label: 'Agnes AI' },
+  { value: 'minimax', label: 'MiniMax' },
   { value: 'custom', label: '自定义 OpenAI-like' },
 ];
 
@@ -275,6 +276,18 @@ const imageProviderDefaults: ImageModelProfiles = {
     tested_at: '',
     last_error: '',
   },
+  minimax: {
+    provider: 'minimax',
+    base_url: 'https://api.minimaxi.com/v1',
+    api_key: '',
+    model_name: 'image-01',
+    image_size: '1024x1024',
+    request_mode: 'normal',
+    concurrency_limit: DEFAULT_IMAGE_CONCURRENCY_LIMIT,
+    status: 'untested',
+    tested_at: '',
+    last_error: '',
+  },
   custom: {
     provider: 'custom',
     base_url: '',
@@ -294,6 +307,7 @@ const imageProviderApiKeyUrls: Record<ImageModelProvider, string> = {
   volcengine: 'https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey',
   'google-ai-studio': 'https://aistudio.google.com/api-keys',
   agnes: 'https://platform.agnes-ai.com/settings/apiKeys',
+  minimax: 'https://platform.minimaxi.com/',
   custom: '',
 };
 
@@ -302,6 +316,7 @@ const imageProviderLabels: Record<ImageModelProvider, string> = {
   volcengine: '火山方舟',
   'google-ai-studio': 'Google AI Studio',
   agnes: 'Agnes AI',
+  minimax: 'MiniMax',
   custom: '自定义生图服务',
 };
 
@@ -310,6 +325,7 @@ function getImageBaseUrlDescription(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '火山方舟 OpenAI 兼容接口地址';
   if (provider === 'agnes') return 'Agnes AI OpenAI 兼容接口地址';
   if (provider === 'custom') return '填写兼容 OpenAI /images/generations 的接口地址';
+  if (provider === 'minimax') return 'MiniMax 图片生成接口地址，国际版为 https://api.minimax.io/v1，国内版为 https://api.minimaxi.com/v1';
   return 'Google Gemini API REST 地址';
 }
 
@@ -318,6 +334,7 @@ function getImageApiKeyDescription(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '用于调用火山方舟图片生成 API';
   if (provider === 'agnes') return '用于调用 Agnes AI 图片生成 API';
   if (provider === 'custom') return '用于调用自定义 OpenAI-like 生图接口';
+  if (provider === 'minimax') return '用于调用 MiniMax 图片生成 API';
   return '用于调用 Google AI Studio Gemini API';
 }
 
@@ -326,6 +343,7 @@ function getImageModelDescription(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '填写火山方舟控制台中已开通的模型或推理接入点 ID';
   if (provider === 'agnes') return '填写 Agnes AI 已开通的生图模型名称';
   if (provider === 'custom') return '填写自定义接口支持的生图模型名称';
+  if (provider === 'minimax') return '填写 MiniMax 已开通的生图模型名称';
   return '选择或填写支持图片生成的 Gemini 模型';
 }
 
@@ -334,6 +352,7 @@ function getImageModelPlaceholder(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '请输入已开通的模型或推理接入点 ID';
   if (provider === 'agnes') return '请输入 Agnes AI 生图模型名称';
   if (provider === 'custom') return '请输入 OpenAI-like 生图模型名称';
+  if (provider === 'minimax') return 'image-01';
   return 'gemini-3.1-flash-image-preview';
 }
 
@@ -349,7 +368,7 @@ function normalizeImageModelProfile(provider: ImageModelProvider, profile?: Part
   const useProviderDefaultImageModel = provider === 'jinlong' && !String(profile?.model_name ?? '').trim();
   return {
     provider,
-    base_url: provider === 'custom' ? profile?.base_url ?? defaults.base_url : defaults.base_url,
+    base_url: provider === 'custom' || provider === 'minimax' ? profile?.base_url ?? defaults.base_url : defaults.base_url,
     api_key: profile?.api_key ?? defaults.api_key,
     model_name: useProviderDefaultImageModel ? defaults.model_name : profile?.model_name ?? defaults.model_name,
     image_size: normalizeImageSize(provider, useProviderDefaultImageModel ? defaults.image_size : profile?.image_size ?? defaults.image_size),
@@ -1910,7 +1929,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                 value={state.imageModel.base_url || ''}
                 placeholder={state.imageModel.provider === 'custom' ? 'https://api.example.com/v1' : imageProviderDefaults[state.imageModel.provider].base_url}
                 onChange={(event) => updateImageModelConfig({ base_url: event.target.value }, { clearModels: true })}
-                disabled={state.imageModel.provider !== 'custom'}
+                disabled={state.imageModel.provider !== 'custom' && state.imageModel.provider !== 'minimax'}
               />
             </label>
             <label className="settings-row">

--- a/client/src/shared/types/config.ts
+++ b/client/src/shared/types/config.ts
@@ -44,7 +44,7 @@ export interface ImageModelTestResult {
   mime_type?: string;
 }
 
-export type ImageModelProvider = 'jinlong' | 'volcengine' | 'google-ai-studio' | 'agnes' | 'custom';
+export type ImageModelProvider = 'jinlong' | 'volcengine' | 'google-ai-studio' | 'agnes' | 'minimax' | 'custom';
 export type ImageModelStatus = 'untested' | 'available' | 'unavailable';
 export type ImageModelSize = 'auto' | '512' | '1K' | '2K' | '4K' | '1024x1024' | '1536x1024' | '1024x1536' | '2048x2048' | '2048x1152' | '3840x2160' | '2160x3840';
 


### PR DESCRIPTION
Reason: The executable image provider layer omitted MiniMax and hardcoded the OpenAI-compatible /images/generations request with a data[0].url / b64_json response shape, so MiniMax text-to-image could not be used.

MiniMax text-to-image is not OpenAI-compatible: it uses the regional `/v1/image_generation` endpoint, its own request fields, and a `data.image_urls` response shape. This change adds MiniMax as a first-class image provider with a dedicated request/response path instead of forcing it through the OpenAI-compatible one.

## Changes
- `client/src/shared/types/config.ts`: add `minimax` to the `ImageModelProvider` union.
- `client/electron/services/configStore.cjs`: register the `minimax` image provider, add its default profile (regional base URL, `image-01`, non-stream request mode), and let its base URL be user-editable so either regional endpoint can be selected.
- `client/electron/services/aiService.cjs`: add the MiniMax image path — a request builder (`model`, `prompt`, `response_format`, `n`, `prompt_optimizer`, plus `aspect_ratio` derived from the configured size enum), a POST to `${baseUrl}/image_generation`, `base_resp.status_code` error handling, and `data.image_urls` parsing (with a `data.image_base64` fallback). It is wired into both image generation and the connectivity test dispatch. Base64 payloads are redacted from logs.
- `client/src/features/settings/pages/SettingsPage.tsx`: expose MiniMax in the image provider selector with its defaults, label, field descriptions, and an editable base URL for regional endpoint selection.
- add `client/electron/services/aiService.minimaxImage.test.cjs` covering the request builder, size-to-aspect-ratio mapping, URL/base64 extraction, status-code error handling, and log redaction.

## Checks
- `node --check` on `client/electron/services/aiService.cjs` and `client/electron/services/configStore.cjs`.
- `node --test client/electron/services/aiService.minimaxImage.test.cjs` — 5 passing.
- `tsc --noEmit` — no errors.
