### PR TITLE
BELL-62: 文本模型增加可调最大输出 Token，默认 32768

### DIFF
--- a/client/electron/services/aiService.cjs
+++ b/client/electron/services/aiService.cjs
@@ -741,6 +741,7 @@ function createChatRequestBody(config, request, options = {}) {
   const body = {
     model: modelName,
     messages: request.messages,
+    max_tokens: config.max_output_tokens,
   };
 
   if (config.temperature_enabled) {
@@ -788,10 +789,11 @@ function createAgentChatRequestBody(config, sourceBody) {
     delete body.reasoning_effort;
   }
 
-  // 部分 OpenAI 兼容上游会拒绝 Agent SDK 注入的输出长度参数。
+  // 丢掉 SDK 注入的输出长度，改写当前配置的 max_output_tokens。
   delete body.max_tokens;
   delete body.max_output_tokens;
   delete body.max_completion_tokens;
+  body.max_tokens = config.max_output_tokens;
   return body;
 }
 

--- a/client/electron/services/configStore.cjs
+++ b/client/electron/services/configStore.cjs
@@ -9,6 +9,9 @@ const imageModelProviders = ['jinlong', 'volcengine', 'google-ai-studio', 'agnes
 const aiRequestModes = ['normal', 'stream'];
 const updateChannels = ['github', 'cloudflare', 'atomgit'];
 const DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT = 400000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 32768;
+const MIN_MAX_OUTPUT_TOKENS = 1024;
+const MAX_MAX_OUTPUT_TOKENS = 128000;
 const DEFAULT_TEXT_CONCURRENCY_LIMIT = 10;
 const DEFAULT_TEXT_TEMPERATURE = 0.7;
 const DEFAULT_IMAGE_CONCURRENCY_LIMIT = 2;
@@ -39,6 +42,7 @@ const defaultTextModelProfiles = {
     model_name: 'gpt-3.5-turbo',
     reasoning_effort: '',
     context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT,
+    max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
     concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT,
     temperature_enabled: false,
     temperature: DEFAULT_TEXT_TEMPERATURE,
@@ -50,6 +54,7 @@ const defaultTextModelProfiles = {
     model_name: '',
     reasoning_effort: '',
     context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT,
+    max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
     concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT,
     temperature_enabled: false,
     temperature: DEFAULT_TEXT_TEMPERATURE,
@@ -61,6 +66,7 @@ const defaultTextModelProfiles = {
     model_name: '',
     reasoning_effort: '',
     context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT,
+    max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
     concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT,
     temperature_enabled: false,
     temperature: DEFAULT_TEXT_TEMPERATURE,
@@ -72,6 +78,7 @@ const defaultTextModelProfiles = {
     model_name: '',
     reasoning_effort: '',
     context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT,
+    max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
     concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT,
     temperature_enabled: false,
     temperature: DEFAULT_TEXT_TEMPERATURE,
@@ -83,6 +90,7 @@ const defaultTextModelProfiles = {
     model_name: '',
     reasoning_effort: '',
     context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT,
+    max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
     concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT,
     temperature_enabled: false,
     temperature: DEFAULT_TEXT_TEMPERATURE,
@@ -97,6 +105,7 @@ const legacyTextModelProfiles = {
     model_name: '',
     reasoning_effort: '',
     context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT,
+    max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
     concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT,
     temperature_enabled: false,
     temperature: DEFAULT_TEXT_TEMPERATURE,
@@ -250,6 +259,7 @@ const defaultConfig = {
   model_name: 'gpt-3.5-turbo',
   reasoning_effort: '',
   context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT,
+  max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS,
   concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT,
   temperature_enabled: false,
   temperature: DEFAULT_TEXT_TEMPERATURE,
@@ -320,6 +330,13 @@ function normalizeTextContextLengthLimit(value, fallback = DEFAULT_TEXT_CONTEXT_
   return Number.isFinite(number) && number > 0 ? Math.floor(number) : fallback;
 }
 
+function normalizeMaxOutputTokens(value, fallback = DEFAULT_MAX_OUTPUT_TOKENS) {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= MIN_MAX_OUTPUT_TOKENS && number <= MAX_MAX_OUTPUT_TOKENS
+    ? Math.floor(number)
+    : fallback;
+}
+
 function normalizeTextConcurrencyLimit(value, fallback = DEFAULT_TEXT_CONCURRENCY_LIMIT) {
   const number = Number(value);
   return Number.isFinite(number) && number > 0 ? Math.round(number) : fallback;
@@ -388,6 +405,7 @@ function normalizeTextModelProfile(provider, profile) {
     model_name: source.model_name !== undefined ? source.model_name : defaults.model_name,
     reasoning_effort: normalizeReasoningEffort(source.reasoning_effort, defaults.reasoning_effort),
     context_length_limit: normalizeTextContextLengthLimit(source.context_length_limit, defaults.context_length_limit),
+    max_output_tokens: normalizeMaxOutputTokens(source.max_output_tokens, defaults.max_output_tokens),
     concurrency_limit: normalizeTextConcurrencyLimit(source.concurrency_limit, defaults.concurrency_limit),
     temperature_enabled: normalizeTextTemperatureEnabled(source.temperature_enabled, defaults.temperature_enabled),
     temperature: normalizeTextTemperature(source.temperature, defaults.temperature),
@@ -421,6 +439,7 @@ function textProfileFromFlatConfig(source, fallback, provider) {
     model_name: source.model_name !== undefined ? source.model_name : fallback.model_name,
     reasoning_effort: normalizeReasoningEffort(source.reasoning_effort, fallback.reasoning_effort),
     context_length_limit: normalizeTextContextLengthLimit(source.context_length_limit !== undefined ? source.context_length_limit : fallback.context_length_limit, fallback.context_length_limit),
+    max_output_tokens: normalizeMaxOutputTokens(source.max_output_tokens !== undefined ? source.max_output_tokens : fallback.max_output_tokens, fallback.max_output_tokens),
     concurrency_limit: normalizeTextConcurrencyLimit(source.concurrency_limit !== undefined ? source.concurrency_limit : fallback.concurrency_limit, fallback.concurrency_limit),
     temperature_enabled: normalizeTextTemperatureEnabled(source.temperature_enabled, fallback.temperature_enabled),
     temperature: normalizeTextTemperature(source.temperature !== undefined ? source.temperature : fallback.temperature, fallback.temperature),
@@ -455,6 +474,7 @@ function textProfileFromUnknownProvider(source, sourceProvider, fallback) {
     model_name: pickTextProfileField(source.model_name, selectedProfile?.model_name, fallback.model_name),
     reasoning_effort: normalizeReasoningEffort(source.reasoning_effort ?? selectedProfile?.reasoning_effort, fallback.reasoning_effort),
     context_length_limit: normalizeTextContextLengthLimit(pickTextProfileField(source.context_length_limit, selectedProfile?.context_length_limit, fallback.context_length_limit), fallback.context_length_limit),
+    max_output_tokens: normalizeMaxOutputTokens(pickTextProfileField(source.max_output_tokens, selectedProfile?.max_output_tokens, fallback.max_output_tokens), fallback.max_output_tokens),
     concurrency_limit: normalizeTextConcurrencyLimit(pickTextProfileField(source.concurrency_limit, selectedProfile?.concurrency_limit, fallback.concurrency_limit), fallback.concurrency_limit),
     temperature_enabled: normalizeTextTemperatureEnabled(source.temperature_enabled ?? selectedProfile?.temperature_enabled, fallback.temperature_enabled),
     temperature: normalizeTextTemperature(pickTextProfileField(source.temperature, selectedProfile?.temperature, fallback.temperature), fallback.temperature),
@@ -715,6 +735,7 @@ function normalizeConfig(config) {
     model_name: activeTextProfile.model_name,
     reasoning_effort: activeTextProfile.reasoning_effort,
     context_length_limit: activeTextProfile.context_length_limit,
+    max_output_tokens: activeTextProfile.max_output_tokens,
     concurrency_limit: activeTextProfile.concurrency_limit,
     temperature_enabled: activeTextProfile.temperature_enabled,
     temperature: activeTextProfile.temperature,

--- a/client/electron/services/pi/piSessionFactory.cjs
+++ b/client/electron/services/pi/piSessionFactory.cjs
@@ -27,9 +27,9 @@ function normalizeContextLimit(value) {
   return Number.isFinite(number) && number > 0 ? Math.floor(number) : 400000;
 }
 
-function normalizeOutputLimit(contextLength) {
-  const normalizedContextLength = normalizeContextLimit(contextLength);
-  return Math.min(32768, normalizedContextLength);
+function normalizeOutputLimit(value) {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? Math.floor(number) : 32768;
 }
 
 // 创建隔离的 Pi Session；持久任务可在后续完整执行中重新打开原 Session。
@@ -53,7 +53,7 @@ async function createPiSession({ workspaceDir, sessionsDir, sessionFile, environ
       reasoning: false,
       input: ['text'],
       contextWindow: normalizeContextLimit(config.context_length_limit),
-      maxTokens: normalizeOutputLimit(config.context_length_limit),
+      maxTokens: normalizeOutputLimit(config.max_output_tokens),
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       compat: {
         supportsDeveloperRole: false,

--- a/client/src/features/settings/pages/SettingsPage.tsx
+++ b/client/src/features/settings/pages/SettingsPage.tsx
@@ -80,16 +80,19 @@ const aiRequestModeOptions: Array<{ value: AiRequestMode; label: string }> = [
 ];
 
 const DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT = 400000;
+const DEFAULT_MAX_OUTPUT_TOKENS = 32768;
+const MIN_MAX_OUTPUT_TOKENS = 1024;
+const MAX_MAX_OUTPUT_TOKENS = 128000;
 const DEFAULT_TEXT_CONCURRENCY_LIMIT = 10;
 const DEFAULT_TEXT_TEMPERATURE = 0.7;
 
 const textProviderDefaults: Record<ConfiguredTextModelProvider, TextModelConfig> = {
-  jinlong: { api_key: '', base_url: 'https://jlaudeapi.com/v1', model_name: 'gpt-3.5-turbo', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
-  volcengine: { api_key: '', base_url: 'https://ark.cn-beijing.volces.com/api/v3', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
-  deepseek: { api_key: '', base_url: 'https://api.deepseek.com', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
-  longcat: { api_key: '', base_url: 'https://api.longcat.chat/openai/v1', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
-  agnes: { api_key: '', base_url: 'https://apihub.agnes-ai.com/v1', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
-  custom: { api_key: '', base_url: '', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
+  jinlong: { api_key: '', base_url: 'https://jlaudeapi.com/v1', model_name: 'gpt-3.5-turbo', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
+  volcengine: { api_key: '', base_url: 'https://ark.cn-beijing.volces.com/api/v3', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
+  deepseek: { api_key: '', base_url: 'https://api.deepseek.com', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
+  longcat: { api_key: '', base_url: 'https://api.longcat.chat/openai/v1', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
+  agnes: { api_key: '', base_url: 'https://apihub.agnes-ai.com/v1', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
+  custom: { api_key: '', base_url: '', model_name: '', reasoning_effort: '', context_length_limit: DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT, max_output_tokens: DEFAULT_MAX_OUTPUT_TOKENS, concurrency_limit: DEFAULT_TEXT_CONCURRENCY_LIMIT, temperature_enabled: false, temperature: DEFAULT_TEXT_TEMPERATURE, request_mode: 'stream' },
 };
 
 const textProviderApiKeyUrls: Partial<Record<ConfiguredTextModelProvider, string>> = {
@@ -115,6 +118,13 @@ function normalizeTextContextLengthLimit(value?: number | string): number {
   return Number.isFinite(number) && number > 0 ? Math.floor(number) : DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT;
 }
 
+function normalizeMaxOutputTokens(value?: number | string): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number >= MIN_MAX_OUTPUT_TOKENS && number <= MAX_MAX_OUTPUT_TOKENS
+    ? Math.floor(number)
+    : DEFAULT_MAX_OUTPUT_TOKENS;
+}
+
 function normalizeTextConcurrencyLimit(value?: number | string): number {
   const number = Number(value);
   return Number.isFinite(number) && number > 0 ? Math.round(number) : DEFAULT_TEXT_CONCURRENCY_LIMIT;
@@ -131,6 +141,12 @@ function parseTextContextLengthInput(value: string): number | '' {
   if (value === '') return '';
   const number = Number(value);
   return Number.isFinite(number) ? Math.max(1, Math.floor(number)) : '';
+}
+
+function parseMaxOutputTokensInput(value: string): number | '' {
+  if (value === '') return '';
+  const number = Number(value);
+  return Number.isFinite(number) ? Math.floor(number) : '';
 }
 
 function parseTextConcurrencyLimitInput(value: string): number | '' {
@@ -153,6 +169,7 @@ function normalizeTextModelProfile(provider: ConfiguredTextModelProvider, profil
     model_name: profile?.model_name ?? defaults.model_name,
     reasoning_effort: profile?.reasoning_effort?.trim() ?? defaults.reasoning_effort,
     context_length_limit: normalizeTextContextLengthLimit(profile?.context_length_limit ?? defaults.context_length_limit),
+    max_output_tokens: normalizeMaxOutputTokens(profile?.max_output_tokens ?? defaults.max_output_tokens),
     concurrency_limit: normalizeTextConcurrencyLimit(profile?.concurrency_limit ?? defaults.concurrency_limit),
     temperature_enabled: profile?.temperature_enabled ?? defaults.temperature_enabled,
     temperature: normalizeTextTemperature(profile?.temperature ?? defaults.temperature),
@@ -183,6 +200,7 @@ function textProfileFromState(textModel: SettingsPageState['textModel']): TextMo
     model_name: textModel.model_name,
     reasoning_effort: textModel.reasoning_effort.trim(),
     context_length_limit: normalizeTextContextLengthLimit(textModel.context_length_limit),
+    max_output_tokens: normalizeMaxOutputTokens(textModel.max_output_tokens),
     concurrency_limit: normalizeTextConcurrencyLimit(textModel.concurrency_limit),
     temperature_enabled: textModel.temperature_enabled,
     temperature: normalizeTextTemperature(textModel.temperature),
@@ -698,6 +716,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
       model_name: activeTextProfile.model_name,
       reasoning_effort: activeTextProfile.reasoning_effort,
       context_length_limit: activeTextProfile.context_length_limit,
+      max_output_tokens: activeTextProfile.max_output_tokens,
       concurrency_limit: activeTextProfile.concurrency_limit,
       temperature_enabled: activeTextProfile.temperature_enabled,
       temperature: activeTextProfile.temperature,
@@ -1827,6 +1846,21 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                   {loadingContextLength ? '获取中' : '获取'}
                 </button>
               </div>
+            </label>
+            <label className="settings-row">
+              <div className="settings-row-copy">
+                <strong>最大输出 Token</strong>
+                <span>单次回复的输出上限，不是上下文窗口。允许 1024–128000，默认 32768</span>
+              </div>
+              <input
+                type="number"
+                min={MIN_MAX_OUTPUT_TOKENS}
+                max={MAX_MAX_OUTPUT_TOKENS}
+                step={1}
+                value={state.textModel.max_output_tokens}
+                placeholder="32768"
+                onChange={(event) => updateTextModelConfig({ max_output_tokens: parseMaxOutputTokensInput(event.target.value) })}
+              />
             </label>
             <label className="settings-row">
               <div className="settings-row-copy">

--- a/client/src/features/settings/types.ts
+++ b/client/src/features/settings/types.ts
@@ -1,8 +1,9 @@
 import type { AgentModeScenariosConfig, ComponentsConfig, ConfiguredTextModelProvider, ImageModelConfig, ImageModelProfiles, TextModelConfig, TextModelProfiles, UpdateChannel } from '../../shared/types';
 
 export interface SettingsPageState {
-  textModel: Omit<TextModelConfig, 'context_length_limit' | 'concurrency_limit'> & {
+  textModel: Omit<TextModelConfig, 'context_length_limit' | 'max_output_tokens' | 'concurrency_limit'> & {
     context_length_limit: number | '';
+    max_output_tokens: number | '';
     concurrency_limit: number | '';
     provider: ConfiguredTextModelProvider;
   };

--- a/client/src/shared/types/config.ts
+++ b/client/src/shared/types/config.ts
@@ -10,6 +10,7 @@ export interface TextModelConfig {
   model_name: string;
   reasoning_effort: string;
   context_length_limit: number;
+  max_output_tokens: number;
   concurrency_limit: number;
   temperature_enabled: boolean;
   temperature: number;


### PR DESCRIPTION
Closes BELL-62

替换因分支重写而无法重开的 #203。本分支从最新 `origin/main`（`582822ff`）cherry-pick 而来，只含本单改动，不带 BELL-61 / `dev` / docx-agent。

## 改动

文本模型 profile 新增独立字段 `max_output_tokens`，和 `context_length_limit` 同级，存 `user_config.json`。

- 默认 **32768**。旧配置缺该字段也按 32768，不再回落 4096
- 允许范围 **1024–128000**，非法值回落 32768
- 不从 `context_length_limit`（默认 400000）推导输出上限

接到当前 `main` 上存在的路径：

1. OpenAI 兼容普通请求：`createChatRequestBody` 带 `max_tokens`
2. Agent 出站：丢掉 SDK 注入的输出长度后，写入配置值
3. Agent / Pi：`piSessionFactory` 的 `maxTokens` 读该字段
4. 设置页在「上下文长度限制」旁增加「最大输出 Token」

## 有意没带

当前 `origin/main` 没有 `textModelProtocol.cjs`（BELL-47 / Anthropic Messages 尚未合入）。没有把该文件或 BELL-47 线带进本 PR。
