### PR TITLE
补齐正式版缺口：暗标检查、目录导入、知识库搜索

### DIFF
--- a/client/electron/ipc/duplicateCheckIpc.cjs
+++ b/client/electron/ipc/duplicateCheckIpc.cjs
@@ -1,11 +1,12 @@
 const { ipcMain } = require('electron');
 
-function registerDuplicateCheckIpc({ duplicateCheckStore }) {
+function registerDuplicateCheckIpc({ duplicateCheckStore, checkResultExportService }) {
   ipcMain.handle('duplicate-check:load-state', () => duplicateCheckStore.loadDuplicateCheck());
   ipcMain.handle('duplicate-check:save-files', (_event, payload) => duplicateCheckStore.saveFiles(payload));
   ipcMain.handle('duplicate-check:save-ui-state', (_event, payload) => duplicateCheckStore.saveUiState(payload));
   ipcMain.handle('duplicate-check:update-state', (_event, partial) => duplicateCheckStore.updateDuplicateCheckWithoutReload(partial));
   ipcMain.handle('duplicate-check:clear', () => duplicateCheckStore.clearDuplicateCheck());
+  ipcMain.handle('duplicate-check:export-excel', () => checkResultExportService.exportDuplicateExcel());
 }
 
 module.exports = {

--- a/client/electron/ipc/index.cjs
+++ b/client/electron/ipc/index.cjs
@@ -16,6 +16,8 @@ const { registerFeasibilityReportIpc } = require('./feasibilityReportIpc.cjs');
 const { registerTemplateIpc } = require('./templateIpc.cjs');
 const { registerSystemFontIpc } = require('./systemFontIpc.cjs');
 const { registerPluginIpc } = require('./pluginIpc.cjs');
+const { createCheckResultExportService } = require('../services/checkResultExportService.cjs');
+const { createOutlineImportService } = require('../services/outlineImportService.cjs');
 const pluginService = require('../services/pluginService.cjs');
 const { createAgentService } = require('../services/agentService.cjs');
 const { createAiService } = require('../services/aiService.cjs');
@@ -121,6 +123,8 @@ const workspaceDatabaseChannels = [
   'technical-plan:set-workflow-kind',
   'technical-plan:save-outline-config',
   'technical-plan:save-outline',
+  'technical-plan:import-outline-document',
+  'technical-plan:export-markdown',
   'technical-plan:save-global-facts-config',
   'technical-plan:save-global-facts',
   'technical-plan:save-content-generation-options',
@@ -144,6 +148,7 @@ const workspaceDatabaseChannels = [
   'duplicate-check:save-ui-state',
   'duplicate-check:update-state',
   'duplicate-check:clear',
+  'duplicate-check:export-excel',
   'rejection-check:load-state',
   'rejection-check:import-document',
   'rejection-check:import-tender-from-technical-plan',
@@ -151,6 +156,7 @@ const workspaceDatabaseChannels = [
   'rejection-check:save-ui-state',
   'rejection-check:update-state',
   'rejection-check:clear',
+  'rejection-check:export-excel',
   'knowledge-base:list',
   'knowledge-base:create-folder',
   'knowledge-base:rename-folder',
@@ -168,6 +174,8 @@ const workspaceDatabaseChannels = [
   'tasks:suppress-outline-selection-auto-confirmation',
   'tasks:start-global-facts-generation',
   'tasks:start-content-generation',
+  'tasks:start-template-fill',
+  'tasks:start-point-to-point',
   'tasks:pause-content-generation',
   'tasks:start-rejection-items-extraction',
   'tasks:start-rejection-check',
@@ -256,6 +264,8 @@ function registerWorkspaceDatabaseServices({ app, configStore, aiService, agentS
   const rejectionCheckStore = createRejectionCheckStore({ app, db: sqliteDatabase.db, fileService, technicalPlanStore, taskLogStore });
   const templateStore = createTemplateStore({ db: sqliteDatabase.db });
   const duplicateCheckService = createDuplicateCheckService({ app, configStore, workspaceStore: duplicateCheckStore });
+  const checkResultExportService = createCheckResultExportService({ rejectionCheckStore, duplicateCheckStore });
+  const outlineImportService = createOutlineImportService({ configStore });
   const taskService = createTaskService({ aiService, agentService, autoConfirmationService, technicalPlanStore, rejectionCheckStore, duplicateCheckStore, feasibilityReportStore, knowledgeBaseService, duplicateCheckService });
   const agentWorkspaceService = createAgentWorkspaceService({ agentService, taskService, technicalPlanStore, feasibilityReportStore });
   agentWorkspaceServiceRef = agentWorkspaceService;
@@ -267,10 +277,10 @@ function registerWorkspaceDatabaseServices({ app, configStore, aiService, agentS
 
   clearWorkspaceDatabaseIpc();
   registerKnowledgeBaseIpc({ knowledgeBaseService });
-  registerTechnicalPlanIpc({ technicalPlanStore, taskService });
+  registerTechnicalPlanIpc({ technicalPlanStore, taskService, outlineImportService });
   registerFeasibilityReportIpc({ feasibilityReportStore, taskService });
-  registerDuplicateCheckIpc({ duplicateCheckStore });
-  registerRejectionCheckIpc({ rejectionCheckStore, taskService });
+  registerDuplicateCheckIpc({ duplicateCheckStore, checkResultExportService });
+  registerRejectionCheckIpc({ rejectionCheckStore, taskService, checkResultExportService });
   registerTemplateIpc({ templateStore });
   registerTaskIpc({ taskService });
   updateStatus({ phase: 'ready', ready: true, message: '本地数据库已就绪' });

--- a/client/electron/ipc/knowledgeBaseIpc.cjs
+++ b/client/electron/ipc/knowledgeBaseIpc.cjs
@@ -15,6 +15,7 @@ function registerKnowledgeBaseIpc({ knowledgeBaseService }) {
   ipcMain.handle('knowledge-base:read-markdown', (_event, documentId) => knowledgeBaseService.readMarkdown(documentId));
   ipcMain.handle('knowledge-base:read-items', (_event, documentId) => knowledgeBaseService.readItems(documentId));
   ipcMain.handle('knowledge-base:read-analysis', (_event, documentId) => knowledgeBaseService.readAnalysis(documentId));
+  ipcMain.handle('knowledge-base:search', (_event, payload) => knowledgeBaseService.search(payload));
 }
 
 module.exports = { registerKnowledgeBaseIpc };

--- a/client/electron/ipc/rejectionCheckIpc.cjs
+++ b/client/electron/ipc/rejectionCheckIpc.cjs
@@ -1,6 +1,6 @@
 const { ipcMain } = require('electron');
 
-function registerRejectionCheckIpc({ rejectionCheckStore, taskService }) {
+function registerRejectionCheckIpc({ rejectionCheckStore, taskService, checkResultExportService }) {
   ipcMain.handle('rejection-check:load-state', () => rejectionCheckStore.loadRejectionCheck());
   ipcMain.handle('rejection-check:import-document', (_event, role, filePaths) => taskService.importRejectionCheckDocument(role, filePaths));
   ipcMain.handle('rejection-check:import-tender-from-technical-plan', () => taskService.importRejectionCheckTenderFromTechnicalPlan());
@@ -8,6 +8,7 @@ function registerRejectionCheckIpc({ rejectionCheckStore, taskService }) {
   ipcMain.handle('rejection-check:save-ui-state', (_event, payload) => rejectionCheckStore.saveUiState(payload));
   ipcMain.handle('rejection-check:update-state', (_event, partial) => rejectionCheckStore.updateRejectionCheckWithoutReload(partial));
   ipcMain.handle('rejection-check:clear', () => taskService.resetRejectionCheck());
+  ipcMain.handle('rejection-check:export-excel', () => checkResultExportService.exportRejectionExcel());
 }
 
 module.exports = {

--- a/client/electron/ipc/taskIpc.cjs
+++ b/client/electron/ipc/taskIpc.cjs
@@ -29,6 +29,14 @@ function registerTaskIpc({ taskService }) {
     taskService.subscribe(event.sender);
     return taskService.startContentGeneration(payload);
   });
+  ipcMain.handle('tasks:start-template-fill', (event, payload) => {
+    taskService.subscribe(event.sender);
+    return taskService.startTemplateFill(payload);
+  });
+  ipcMain.handle('tasks:start-point-to-point', (event, payload) => {
+    taskService.subscribe(event.sender);
+    return taskService.startPointToPoint(payload);
+  });
   ipcMain.handle('tasks:pause-content-generation', (event) => {
     taskService.subscribe(event.sender);
     return taskService.pauseContentGeneration();

--- a/client/electron/ipc/technicalPlanIpc.cjs
+++ b/client/electron/ipc/technicalPlanIpc.cjs
@@ -1,6 +1,6 @@
 const { ipcMain } = require('electron');
 
-function registerTechnicalPlanIpc({ technicalPlanStore, taskService }) {
+function registerTechnicalPlanIpc({ technicalPlanStore, taskService, outlineImportService }) {
   ipcMain.handle('technical-plan:load-state', () => technicalPlanStore.loadTechnicalPlan());
   ipcMain.handle('technical-plan:import-tender-document', (_event, filePaths) => taskService.importTenderDocument(filePaths));
   ipcMain.handle('technical-plan:remove-tender-document', (_event, sourceId) => taskService.removeTenderDocument(sourceId));
@@ -17,6 +17,8 @@ function registerTechnicalPlanIpc({ technicalPlanStore, taskService }) {
   ipcMain.handle('technical-plan:save-outline-config', (_event, payload) => technicalPlanStore.saveOutlineConfig(payload));
   ipcMain.handle('technical-plan:save-outline-selection', (_event, payload) => technicalPlanStore.saveOutlineSelection(payload));
   ipcMain.handle('technical-plan:save-outline', (_event, outlineData) => technicalPlanStore.saveOutline(outlineData));
+  ipcMain.handle('technical-plan:import-outline-document', (_event, filePaths) => outlineImportService.importOutlineDocument(filePaths));
+  ipcMain.handle('technical-plan:export-markdown', (_event, payload) => outlineImportService.exportMarkdownFile(payload));
   ipcMain.handle('technical-plan:save-global-facts-config', (_event, payload) => technicalPlanStore.saveGlobalFactsConfig(payload));
   ipcMain.handle('technical-plan:save-global-facts', (_event, globalFacts) => technicalPlanStore.saveGlobalFacts(globalFacts));
   ipcMain.handle('technical-plan:save-content-generation-options', (_event, options) => technicalPlanStore.saveContentGenerationOptions(options));

--- a/client/electron/preload.cjs
+++ b/client/electron/preload.cjs
@@ -146,6 +146,7 @@ const bridge = {
     readMarkdown: (documentId) => ipcRenderer.invoke('knowledge-base:read-markdown', documentId),
     readItems: (documentId) => ipcRenderer.invoke('knowledge-base:read-items', documentId),
     readAnalysis: (documentId) => ipcRenderer.invoke('knowledge-base:read-analysis', documentId),
+    search: (payload) => ipcRenderer.invoke('knowledge-base:search', payload),
     onEvent: (callback) => {
       const listener = (_event, payload) => callback(payload);
       ipcRenderer.on('knowledge-base:event', listener);

--- a/client/electron/preload.cjs
+++ b/client/electron/preload.cjs
@@ -169,6 +169,8 @@ const bridge = {
     saveOutlineConfig: (payload) => ipcRenderer.invoke('technical-plan:save-outline-config', payload),
     saveOutlineSelection: (payload) => ipcRenderer.invoke('tasks:confirm-outline-selection', payload),
     saveOutline: (outlineData) => ipcRenderer.invoke('technical-plan:save-outline', outlineData),
+    importOutlineDocument: (filePaths) => ipcRenderer.invoke('technical-plan:import-outline-document', filePaths),
+    exportMarkdown: (payload) => ipcRenderer.invoke('technical-plan:export-markdown', payload),
     saveGlobalFactsConfig: (payload) => ipcRenderer.invoke('technical-plan:save-global-facts-config', payload),
     saveGlobalFacts: (globalFacts) => ipcRenderer.invoke('technical-plan:save-global-facts', globalFacts),
     saveContentGenerationOptions: (options) => ipcRenderer.invoke('technical-plan:save-content-generation-options', options),
@@ -196,6 +198,7 @@ const bridge = {
     saveUiState: (payload) => ipcRenderer.invoke('duplicate-check:save-ui-state', payload),
     updateState: (partial) => ipcRenderer.invoke('duplicate-check:update-state', partial),
     clear: () => ipcRenderer.invoke('duplicate-check:clear'),
+    exportExcel: () => ipcRenderer.invoke('duplicate-check:export-excel'),
   },
   rejectionCheck: {
     loadState: () => ipcRenderer.invoke('rejection-check:load-state'),
@@ -205,6 +208,7 @@ const bridge = {
     saveUiState: (payload) => ipcRenderer.invoke('rejection-check:save-ui-state', payload),
     updateState: (partial) => ipcRenderer.invoke('rejection-check:update-state', partial),
     clear: () => ipcRenderer.invoke('rejection-check:clear'),
+    exportExcel: () => ipcRenderer.invoke('rejection-check:export-excel'),
   },
   templates: {
     list: () => ipcRenderer.invoke('templates:list'),
@@ -220,6 +224,8 @@ const bridge = {
     suppressOutlineSelectionAutoConfirmation: (payload) => ipcRenderer.invoke('tasks:suppress-outline-selection-auto-confirmation', payload),
     startGlobalFactsGeneration: (payload) => ipcRenderer.invoke('tasks:start-global-facts-generation', payload),
     startContentGeneration: (payload) => ipcRenderer.invoke('tasks:start-content-generation', payload),
+    startTemplateFill: (payload) => ipcRenderer.invoke('tasks:start-template-fill', payload),
+    startPointToPoint: (payload) => ipcRenderer.invoke('tasks:start-point-to-point', payload),
     pauseContentGeneration: () => ipcRenderer.invoke('tasks:pause-content-generation'),
     startRejectionItemsExtraction: (payload) => ipcRenderer.invoke('tasks:start-rejection-items-extraction', payload),
     startRejectionCheck: (payload) => ipcRenderer.invoke('tasks:start-rejection-check', payload),

--- a/client/electron/services/aiService.cjs
+++ b/client/electron/services/aiService.cjs
@@ -1411,6 +1411,7 @@ async function testOpenAICompatibleImageModel(app, config, provider) {
     size: normalizeOpenAICompatibleImageSize(imageConfig),
     response_format: 'url',
     ...(requestMode === 'stream' ? { stream: true } : {}),
+    ...(provider === 'volcengine' ? { watermark: false } : {}),
   };
 
   try {
@@ -1610,6 +1611,7 @@ async function generateOpenAICompatibleImage(app, config, request, provider) {
     size: normalizeOpenAICompatibleImageSize(imageConfig, request.size),
     response_format: 'url',
     ...(requestMode === 'stream' ? { stream: true } : {}),
+    ...(provider === 'volcengine' ? { watermark: false } : {}),
   };
   const baseUrl = requireBaseUrl(imageConfig.base_url, `${meta.label} Base URL 缺失，请重新选择服务商后保存配置`);
   let responseData = null;

--- a/client/electron/services/bidAnalysisTask.cjs
+++ b/client/electron/services/bidAnalysisTask.cjs
@@ -165,6 +165,14 @@ function isSelectableBidAnalysisTask(task) {
   return task.id !== 'bidBriefing';
 }
 
+function createIdleBidAnalysisItem(task) {
+  return { id: task.id, label: task.label, status: 'idle', content: '' };
+}
+
+function shouldInvalidateBidBriefing(tasksToRun) {
+  return (Array.isArray(tasksToRun) ? tasksToRun : []).some((task) => task?.id && task.id !== 'bidBriefing');
+}
+
 function getBidAnalysisTasks(mode) {
   const selectable = tasks.filter(isSelectableBidAnalysisTask);
   return mode === 'full' ? selectable : selectable.filter((task) => task.required);
@@ -372,7 +380,7 @@ async function runBidAnalysisTask({ aiService, workspaceStore, updateTask, check
   if (forceRerun && !requestedTaskIds) {
     const resetTasks = {};
     for (const task of selectedTasks) {
-      const resetTask = { id: task.id, label: task.label, status: 'idle', content: '' };
+      const resetTask = createIdleBidAnalysisItem(task);
       currentTasks[task.id] = resetTask;
       resetTasks[task.id] = resetTask;
     }
@@ -398,12 +406,26 @@ async function runBidAnalysisTask({ aiService, workspaceStore, updateTask, check
       },
     };
   }
+  const tasksToRun = requestedTaskIds || forceRerun ? scopedTasks : scopedTasks.filter((task) => currentTasks[task.id]?.status !== 'success');
+  if (shouldInvalidateBidBriefing(tasksToRun)) {
+    const briefingTask = getBidAnalysisTaskById('bidBriefing');
+    if (briefingTask) {
+      const resetBriefing = createIdleBidAnalysisItem(briefingTask);
+      currentTasks[briefingTask.id] = resetBriefing;
+      initialPartial = {
+        ...initialPartial,
+        bidAnalysisTasks: {
+          ...(initialPartial.bidAnalysisTasks || {}),
+          [briefingTask.id]: resetBriefing,
+        },
+      };
+    }
+  }
   checkpointTask(
     { status: 'running', progress: 0, logs: initialLogs },
     initialPartial,
     initialEventPatch,
   );
-  const tasksToRun = requestedTaskIds || forceRerun ? scopedTasks : scopedTasks.filter((task) => currentTasks[task.id]?.status !== 'success');
 
   function checkpointBidItem(taskPartial, item, progress, technicalPlanPatch = {}) {
     checkpointTask(
@@ -507,4 +529,5 @@ module.exports = {
   runBidAnalysisTask,
   runBidAnalysisPromptTask,
   runSingleBidAnalysisPromptTask,
+  shouldInvalidateBidBriefing,
 };

--- a/client/electron/services/bidAnalysisTask.cjs
+++ b/client/electron/services/bidAnalysisTask.cjs
@@ -151,17 +151,30 @@ const tasks = [
   { id: 'discardedBids', label: '无效标与废标项', required: false, output: 'markdown', description: '投标无效、废标相关风险项。', prompt: buildInvalidBidAndRejectionItemsPrompt },
   { id: 'signingProcess', label: '合同授予与签订', required: false, output: 'json', description: '中标公示、合同签订、履约保证金和合同文本。', prompt: () => jsonTask('提取合同授予和签订流程', '提取中标公示、合同签订、履约保证金、合同文本等信息。', `{"bid_notice":"中标公示","contract_sign":"合同签订","performance_bond":"履约保证金","contract_text":"合同文本"}`) },
   { id: 'terminationCondition', label: '合同解除和终止', required: false, output: 'json', description: '违约解除、不可抗力、合同终止和争议解决。', prompt: () => jsonTask('提取合同解除和终止条件', '提取违约解除、不可抗力、合同终止、争议解决等信息。', `{"breach_termination":"违约解除","force_majeure":"不可抗力","contract_termination":"合同终止","dispute_resolution":"争议解决"}`) },
+  {
+    id: 'bidBriefing',
+    label: '项目简报',
+    required: false,
+    output: 'markdown',
+    description: '根据已解析项整理一页项目简报，不进入默认关键项。',
+    prompt: () => '任务：根据已解析成功的招标要点整理一页项目简报。',
+  },
 ];
 
+function isSelectableBidAnalysisTask(task) {
+  return task.id !== 'bidBriefing';
+}
+
 function getBidAnalysisTasks(mode) {
-  return mode === 'full' ? tasks : tasks.filter((task) => task.required);
+  const selectable = tasks.filter(isSelectableBidAnalysisTask);
+  return mode === 'full' ? selectable : selectable.filter((task) => task.required);
 }
 
 function normalizeBidAnalysisTaskIds(taskIds) {
   const requestedIds = new Set((Array.isArray(taskIds) ? taskIds : [])
     .map((taskId) => String(taskId || '').trim())
     .filter(Boolean));
-  return tasks.filter((task) => requestedIds.has(task.id)).map((task) => task.id);
+  return tasks.filter((task) => isSelectableBidAnalysisTask(task) && requestedIds.has(task.id)).map((task) => task.id);
 }
 
 function normalizeBidAnalysisConfig(mode, selectedTaskIds) {
@@ -244,6 +257,42 @@ async function runBidAnalysisPromptTask({ aiService, fileContent, fileSegments, 
   });
 }
 
+function buildBidBriefingPrompt(currentTasks = {}) {
+  const sourceItems = tasks
+    .filter((task) => task.id !== 'bidBriefing')
+    .map((task) => currentTasks[task.id])
+    .filter((item) => item?.status === 'success' && String(item.content || '').trim());
+  const sourceText = sourceItems.length
+    ? sourceItems.map((item) => `## ${item.label}\n${String(item.content || '').trim()}`).join('\n\n')
+    : '暂无已成功解析项。';
+  return `任务：根据已解析成功的招标要点，整理一页项目简报。
+
+输出要求：
+1. 只输出 Markdown，不要代码块包裹。
+2. 用加粗标注黑体要点。
+3. 必须响应的事项前加 ★，评分重点前加 ▲。
+4. 单独列出废标风险、目录/响应文件要求、商务做什么、技术做什么。
+5. 不要编造未出现的信息；缺失写“未提及”。
+6. 控制在一页可读范围内。
+
+已解析要点：
+${sourceText}`;
+}
+
+async function runBidBriefingPromptTask({ aiService, currentTasks, sectionHint }) {
+  const messages = [
+    { role: 'system', content: stableSystemPrompt },
+  ];
+  if (sectionHint) {
+    messages.push({ role: 'system', content: sectionHint });
+  }
+  messages.push({ role: 'user', content: buildBidBriefingPrompt(currentTasks) });
+  return aiService.chat({
+    messages,
+    logTitle: '招标解析-项目简报',
+  });
+}
+
 function runInvalidBidAndRejectionItemsExtraction({ aiService, fileContent, sectionHint }) {
   const task = getBidAnalysisTaskById('discardedBids');
   if (!task) {
@@ -257,7 +306,7 @@ async function runBidAnalysisTask({ aiService, workspaceStore, updateTask, check
   const config = normalizeBidAnalysisConfig(payload.mode, payload.selected_task_ids || payload.selectedTaskIds);
   const mode = config.mode;
   const selectedTaskIdSet = new Set(config.taskIds);
-  const selectedTasks = tasks.filter((task) => selectedTaskIdSet.has(task.id));
+  const selectedTasks = tasks.filter((task) => selectedTaskIdSet.has(task.id) && isSelectableBidAnalysisTask(task));
   const fileContent = workspaceStore.readTenderMarkdown();
   if (!String(fileContent || '').trim()) {
     throw new Error('请先上传招标文件，再开始解析');
@@ -288,15 +337,23 @@ async function runBidAnalysisTask({ aiService, workspaceStore, updateTask, check
   const requestedTaskIds = Array.isArray(payload.task_ids)
     ? new Set(payload.task_ids.filter((taskId) => typeof taskId === 'string'))
     : null;
-  const scopedTasks = requestedTaskIds
+  const briefingRequested = Boolean(requestedTaskIds?.has('bidBriefing'));
+  const briefingOnly = briefingRequested && [...requestedTaskIds].every((taskId) => taskId === 'bidBriefing');
+  let scopedTasks = requestedTaskIds
     ? selectedTasks.filter((task) => requestedTaskIds.has(task.id))
     : selectedTasks;
+  if (briefingRequested && !scopedTasks.some((task) => task.id === 'bidBriefing')) {
+    const briefingTask = getBidAnalysisTaskById('bidBriefing');
+    if (briefingTask) scopedTasks = [...scopedTasks, briefingTask];
+  }
   if (requestedTaskIds && scopedTasks.length === 0) {
     throw new Error('未找到可重新解析的招标文件解析项');
   }
   function doneProgress(nextTasks) {
-    const done = selectedTasks.filter((task) => ['success', 'error'].includes(nextTasks[task.id]?.status)).length;
-    return Math.round((done / selectedTasks.length) * 100);
+    const tracked = briefingOnly ? scopedTasks : selectedTasks;
+    if (!tracked.length) return 0;
+    const done = tracked.filter((task) => ['success', 'error'].includes(nextTasks[task.id]?.status)).length;
+    return Math.round((done / tracked.length) * 100);
   }
 
   function getMissingRequiredTasks(nextTasks) {
@@ -366,13 +423,15 @@ async function runBidAnalysisTask({ aiService, workspaceStore, updateTask, check
       runningProgress,
     );
 
-    const content = await runBidAnalysisPromptTask({
-      aiService,
-      fileContent,
-      fileSegments,
-      task,
-      sectionHint,
-    });
+    const content = task.id === 'bidBriefing'
+      ? await runBidBriefingPromptTask({ aiService, currentTasks, sectionHint })
+      : await runBidAnalysisPromptTask({
+        aiService,
+        fileContent,
+        fileSegments,
+        task,
+        sectionHint,
+      });
     const trimmedContent = String(content || '').trim();
     if (!trimmedContent) {
       throw new Error(`${task.label}解析结果为空，请重新解析`);
@@ -428,7 +487,7 @@ async function runBidAnalysisTask({ aiService, workspaceStore, updateTask, check
   }
   await Promise.all(remainingTasks.map(runOneSafely));
 
-  const missingRequiredTasks = getMissingRequiredTasks(currentTasks);
+  const missingRequiredTasks = briefingOnly ? [] : getMissingRequiredTasks(currentTasks);
   if (missingRequiredTasks.length) {
     const missingLabels = missingRequiredTasks.map((task) => task.label).join('、');
     const message = `必填解析项未完成：${missingLabels}，请重新解析失败项。`;

--- a/client/electron/services/bidAnalysisTask.test.cjs
+++ b/client/electron/services/bidAnalysisTask.test.cjs
@@ -1,0 +1,15 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { shouldInvalidateBidBriefing } = require('./bidAnalysisTask.cjs');
+
+describe('shouldInvalidateBidBriefing', () => {
+  it('invalidates when any source analysis item will rerun', () => {
+    assert.equal(shouldInvalidateBidBriefing([{ id: 'projectOverview' }]), true);
+    assert.equal(shouldInvalidateBidBriefing([{ id: 'projectOverview' }, { id: 'bidBriefing' }]), true);
+  });
+
+  it('keeps the briefing when only the briefing itself is requested', () => {
+    assert.equal(shouldInvalidateBidBriefing([{ id: 'bidBriefing' }]), false);
+    assert.equal(shouldInvalidateBidBriefing([]), false);
+  });
+});

--- a/client/electron/services/checkResultExportService.cjs
+++ b/client/electron/services/checkResultExportService.cjs
@@ -1,0 +1,229 @@
+const { app, dialog } = require('electron');
+const fs = require('node:fs');
+const path = require('node:path');
+const XLSX = require('xlsx');
+
+const identityCategoryLabels = {
+  person: '人名或简称',
+  org: '单位名称',
+  project: '项目或编号',
+  contact: '联系方式',
+  region: '地区名称',
+  english: '英文或单位',
+  punctuation: '英文标点或符号',
+  custom: '补充词',
+};
+
+function formatExportTimestamp() {
+  const now = new Date();
+  const pad = (value) => String(value).padStart(2, '0');
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}`;
+}
+
+function sanitizeFilename(name) {
+  return String(name || '')
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80) || '检查结果';
+}
+
+function createSheet(headers, rows) {
+  return XLSX.utils.aoa_to_sheet([headers, ...rows]);
+}
+
+function appendSheet(workbook, name, headers, rows) {
+  XLSX.utils.book_append_sheet(workbook, createSheet(headers, rows), name);
+}
+
+async function saveWorkbook(workbook, title, defaultFilename) {
+  const defaultDir = app?.getPath ? app.getPath('downloads') : process.env.USERPROFILE || process.cwd();
+  const result = await dialog.showSaveDialog({
+    title,
+    defaultPath: path.join(defaultDir, defaultFilename),
+    filters: [{ name: 'Excel 工作簿', extensions: ['xlsx'] }],
+  });
+  if (result.canceled || !result.filePath) {
+    return { success: false, canceled: true, message: '已取消导出' };
+  }
+
+  const outputPath = result.filePath.endsWith('.xlsx') ? result.filePath : `${result.filePath}.xlsx`;
+  const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+  fs.writeFileSync(outputPath, buffer);
+  return { success: true, path: outputPath, message: 'Excel 已导出。' };
+}
+
+function fileNameById(documents = [], documentId) {
+  return documents.find((document) => document.id === documentId)?.fileName || documentId || '';
+}
+
+function hasRejectionExportableResults(state) {
+  const results = [
+    state?.rejectionCheckResult,
+    state?.typoCheckResult,
+    state?.logicCheckResult,
+    state?.identityCheckResult,
+  ];
+  return results.some((result) => {
+    if (!result) return false;
+    return result.status === 'success' || result.status === 'error' || (Array.isArray(result.findings) && result.findings.length > 0);
+  });
+}
+
+function hasDuplicateExportableResults(state) {
+  return Boolean(
+    state?.metadataAnalysis?.rows?.length
+    || state?.outlineAnalysis?.duplicateGroups?.length
+    || state?.contentAnalysis?.duplicateSentences?.length
+    || state?.imageAnalysis?.duplicateImages?.length
+    || state?.metadataAnalysis?.status === 'success'
+    || state?.outlineAnalysis?.status === 'success'
+    || state?.contentAnalysis?.status === 'success'
+    || state?.imageAnalysis?.status === 'success',
+  );
+}
+
+function buildRejectionWorkbook(state) {
+  const bidDocuments = Array.isArray(state.bidDocuments) ? state.bidDocuments : [];
+  const workbook = XLSX.utils.book_new();
+  const typeLabels = { invalidBid: '无效标', rejectionItem: '废标项' };
+  const severityLabels = { high: '高风险', medium: '中风险', low: '低风险' };
+
+  appendSheet(workbook, '废标项', [
+    '投标文件', '类型', '风险等级', '标题', '摘要', '招标要求', '投标证据', '风险原因', '建议',
+  ], (state.rejectionCheckResult?.findings || []).map((item) => [
+    fileNameById(bidDocuments, item.bidDocumentId),
+    typeLabels[item.type] || item.type || '',
+    severityLabels[item.severity] || item.severity || '',
+    item.title || '',
+    item.summary || '',
+    item.requirement || '',
+    item.bidEvidence || '',
+    item.riskReason || '',
+    item.suggestion || '',
+  ]));
+
+  appendSheet(workbook, '错别字', [
+    '投标文件', '错误文本', '建议改正', '原文摘录', '原因', '位置',
+  ], (state.typoCheckResult?.findings || []).map((item) => [
+    fileNameById(bidDocuments, item.bidDocumentId),
+    item.wrongText || '',
+    item.correctText || '',
+    item.originalExcerpt || '',
+    item.reason || '',
+    item.locationHint || '',
+  ]));
+
+  appendSheet(workbook, '逻辑', [
+    '投标文件', '标题', '原文', '位置', '问题原因', '建议',
+  ], (state.logicCheckResult?.findings || []).map((item) => [
+    fileNameById(bidDocuments, item.bidDocumentId),
+    item.title || '',
+    item.originalText || '',
+    item.locationHint || '',
+    item.fallacyReason || '',
+    item.suggestion || '',
+  ]));
+
+  appendSheet(workbook, '暗标', [
+    '投标文件', '类别', '命中文本', '原文摘录', '位置', '风险原因', '建议',
+  ], (state.identityCheckResult?.findings || []).map((item) => [
+    fileNameById(bidDocuments, item.bidDocumentId),
+    identityCategoryLabels[item.category] || item.category || '',
+    item.matchedText || '',
+    item.originalExcerpt || '',
+    item.locationHint || '',
+    item.riskReason || '',
+    item.suggestion || '',
+  ]));
+
+  return workbook;
+}
+
+function fileNameFromDuplicate(state, fileId) {
+  const files = [
+    ...(Array.isArray(state.tenderFiles) ? state.tenderFiles : []),
+    ...(Array.isArray(state.bidFiles) ? state.bidFiles : []),
+    state.tenderFile,
+  ].filter(Boolean);
+  return files.find((file) => file.id === fileId)?.file_name || fileId || '';
+}
+
+function joinFileNames(state, fileIds = []) {
+  return (Array.isArray(fileIds) ? fileIds : []).map((fileId) => fileNameFromDuplicate(state, fileId)).filter(Boolean).join('；');
+}
+
+function buildDuplicateWorkbook(state) {
+  const workbook = XLSX.utils.book_new();
+  const bidFiles = Array.isArray(state.bidFiles) ? state.bidFiles : [];
+
+  appendSheet(workbook, '元数据', [
+    '字段', '重复文件', '同日文件', ...bidFiles.map((file) => file.file_name || file.id),
+  ], (state.metadataAnalysis?.rows || []).map((row) => [
+    row.label || row.key || '',
+    joinFileNames(state, row.duplicate_file_ids),
+    joinFileNames(state, row.same_day_file_ids),
+    ...bidFiles.map((file) => (row.values && row.values[file.id]) || ''),
+  ]));
+
+  appendSheet(workbook, '目录', [
+    '类型', '标题', '相似度', '涉及文件', '路径',
+  ], (state.outlineAnalysis?.duplicateGroups || []).map((group) => [
+    group.type === 'similar' ? '相似' : '重复',
+    group.title || '',
+    Number.isFinite(Number(group.score)) ? Number(group.score) : '',
+    joinFileNames(state, group.file_ids),
+    Object.values(group.paths || {}).flat().join(' / '),
+  ]));
+
+  appendSheet(workbook, '重复句子', [
+    '句子', '涉及文件', '出现次数',
+  ], (state.contentAnalysis?.duplicateSentences || []).map((item) => [
+    item.sentence || '',
+    joinFileNames(state, item.file_ids),
+    Object.values(item.occurrences || {}).reduce((sum, count) => sum + Number(count || 0), 0),
+  ]));
+
+  appendSheet(workbook, '重复图片', [
+    '图片哈希', '涉及文件', '出现位置',
+  ], (state.imageAnalysis?.duplicateImages || []).map((item) => [
+    item.hash || '',
+    joinFileNames(state, item.file_ids),
+    Object.entries(item.locations || {}).flatMap(([fileId, locations]) => (
+      (locations || []).map((location) => `${fileNameFromDuplicate(state, fileId)}：${location.previous_sentence || location.directory || ''}`)
+    )).join('；'),
+  ]));
+
+  return workbook;
+}
+
+function createCheckResultExportService({ rejectionCheckStore, duplicateCheckStore } = {}) {
+  return {
+    async exportRejectionExcel() {
+      const state = rejectionCheckStore.loadRejectionCheck();
+      if (!hasRejectionExportableResults(state)) {
+        throw new Error('当前没有可导出的检查结果');
+      }
+      return saveWorkbook(
+        buildRejectionWorkbook(state),
+        '导出废标项检查结果',
+        `${sanitizeFilename('废标项检查结果')}_${formatExportTimestamp()}.xlsx`,
+      );
+    },
+    async exportDuplicateExcel() {
+      const state = duplicateCheckStore.loadDuplicateCheck();
+      if (!hasDuplicateExportableResults(state)) {
+        throw new Error('当前没有可导出的查重结果');
+      }
+      return saveWorkbook(
+        buildDuplicateWorkbook(state),
+        '导出标书查重结果',
+        `${sanitizeFilename('标书查重结果')}_${formatExportTimestamp()}.xlsx`,
+      );
+    },
+  };
+}
+
+module.exports = {
+  createCheckResultExportService,
+};

--- a/client/electron/services/configStore.cjs
+++ b/client/electron/services/configStore.cjs
@@ -381,12 +381,21 @@ function normalizeComponentsConfig(source) {
   };
 }
 
+function allowsEditableBaseUrl(provider) {
+  return provider === 'custom' || provider === 'volcengine';
+}
+
+function resolvePersistedBaseUrl(provider, sourceBaseUrl, defaultBaseUrl) {
+  if (allowsEditableBaseUrl(provider)) {
+    return sourceBaseUrl !== undefined ? sourceBaseUrl : defaultBaseUrl;
+  }
+  return defaultBaseUrl;
+}
+
 function normalizeTextModelProfile(provider, profile) {
   const defaults = defaultTextModelProfiles[provider] || legacyTextModelProfiles[provider];
   const source = profile || {};
-  const sourceBaseUrl = provider === 'custom'
-    ? source.base_url !== undefined ? source.base_url : defaults.base_url
-    : defaults.base_url;
+  const sourceBaseUrl = resolvePersistedBaseUrl(provider, source.base_url, defaults.base_url);
   return {
     api_key: source.api_key !== undefined ? source.api_key : defaults.api_key,
     base_url: sourceBaseUrl,
@@ -417,9 +426,11 @@ function normalizeTextModelProfiles(sourceProfiles) {
 }
 
 function textProfileFromFlatConfig(source, fallback, provider) {
-  const sourceBaseUrl = provider === 'custom'
-    ? source.base_url !== undefined ? source.base_url : fallback.base_url
-    : fallback.base_url;
+  const sourceBaseUrl = resolvePersistedBaseUrl(
+    provider,
+    source.base_url !== undefined ? source.base_url : undefined,
+    fallback.base_url,
+  );
   return {
     api_key: source.api_key !== undefined ? source.api_key : fallback.api_key,
     base_url: sourceBaseUrl,
@@ -492,9 +503,7 @@ function normalizeImageModelProfile(provider, profile) {
   const useProviderDefaultImageModel = provider === 'jinlong' && !String(source.model_name ?? '').trim();
   return {
     provider,
-    base_url: provider === 'custom'
-      ? source.base_url !== undefined ? source.base_url : defaults.base_url
-      : defaults.base_url,
+    base_url: resolvePersistedBaseUrl(provider, source.base_url, defaults.base_url),
     api_key: source.api_key !== undefined ? source.api_key : defaults.api_key,
     model_name: useProviderDefaultImageModel ? defaults.model_name : source.model_name !== undefined ? source.model_name : defaults.model_name,
     image_size: normalizeImageSize(provider, useProviderDefaultImageModel ? defaults.image_size : source.image_size, defaults.image_size),

--- a/client/electron/services/configStore.cjs
+++ b/client/electron/services/configStore.cjs
@@ -240,6 +240,11 @@ const defaultExportFormat = {
     caption_bold: false,
     caption_italic: false,
   },
+  text_normalization: {
+    chinese_quotes: false,
+    strip_spaces: false,
+  },
+  include_table_of_contents: false,
 };
 
 const defaultConfig = {
@@ -547,6 +552,8 @@ function cloneDefaultExportFormat(def = defaultExportFormat) {
       body_cell: { ...def.table.body_cell },
     },
     image: { ...def.image },
+    text_normalization: { ...def.text_normalization },
+    include_table_of_contents: def.include_table_of_contents,
   };
 }
 
@@ -661,6 +668,7 @@ function normalizeExportFormat(source) {
   };
 
   const image = normalizeImageStyle(source.image, def.image);
+  const srcNormalization = source.text_normalization && typeof source.text_normalization === 'object' ? source.text_normalization : {};
 
   return {
     template_name: typeof source.template_name === 'string' && source.template_name ? source.template_name : def.template_name,
@@ -671,6 +679,11 @@ function normalizeExportFormat(source) {
     body_text,
     table,
     image,
+    text_normalization: {
+      chinese_quotes: typeof srcNormalization.chinese_quotes === 'boolean' ? srcNormalization.chinese_quotes : def.text_normalization.chinese_quotes,
+      strip_spaces: typeof srcNormalization.strip_spaces === 'boolean' ? srcNormalization.strip_spaces : def.text_normalization.strip_spaces,
+    },
+    include_table_of_contents: typeof source.include_table_of_contents === 'boolean' ? source.include_table_of_contents : def.include_table_of_contents,
   };
 }
 

--- a/client/electron/services/exportService.cjs
+++ b/client/electron/services/exportService.cjs
@@ -12,6 +12,7 @@ const { renderMarkdownHtml } = require('../utils/renderMarkdownHtml.cjs');
 const { getLocalImageRenderService } = require('./localImageRenderService.cjs');
 const {
   AlignmentType,
+  Bookmark,
   BorderStyle,
   Document,
   ExternalHyperlink,
@@ -23,14 +24,16 @@ const {
   LevelFormat,
   LevelSuffix,
   Packer,
-  PageNumber,
   PageBreak,
+  PageNumber,
   PageOrientation,
+  PageReference,
   Paragraph,
   ShadingType,
   Table,
   TableCell,
   TableLayoutType,
+  TableOfContents,
   TableRow,
   TextRun,
   UnderlineType,
@@ -245,6 +248,98 @@ function cleanText(value) {
   return String(value || '').replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
 }
 
+function convertChineseQuotes(value) {
+  let result = '';
+  let doubleOpen = true;
+  let singleOpen = true;
+  const text = String(value || '');
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === '"') {
+      result += doubleOpen ? '“' : '”';
+      doubleOpen = !doubleOpen;
+      continue;
+    }
+    if (char === "'") {
+      const prev = text[index - 1] || '';
+      const next = text[index + 1] || '';
+      if (/[A-Za-z]/.test(prev) && /[A-Za-z]/.test(next)) {
+        result += char;
+        continue;
+      }
+      result += singleOpen ? '‘' : '’';
+      singleOpen = !singleOpen;
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+function stripChineseSpaces(value) {
+  return String(value || '').replace(/([\u3400-\u9FFF\uF900-\uFAFF])[ \t]+(?=[\u3400-\u9FFF\uF900-\uFAFF])/g, '$1');
+}
+
+function applyTextNormalization(value, options) {
+  if (!options?.chinese_quotes && !options?.strip_spaces) return String(value || '');
+  let text = String(value || '');
+  if (options.chinese_quotes) text = convertChineseQuotes(text);
+  if (options.strip_spaces) text = stripChineseSpaces(text);
+  return text;
+}
+
+function applyTextNormalizationToMarkdown(markdown, options) {
+  if (!options?.chinese_quotes && !options?.strip_spaces) return String(markdown || '');
+  const preserved = [];
+  const protectedText = String(markdown || '')
+    .replace(/```[\s\S]*?```/g, (block) => {
+      preserved.push(block);
+      return `\0FENCE${preserved.length - 1}\0`;
+    })
+    .replace(/`[^`\n]+`/g, (block) => {
+      preserved.push(block);
+      return `\0FENCE${preserved.length - 1}\0`;
+    });
+  return applyTextNormalization(protectedText, options).replace(/\0FENCE(\d+)\0/g, (_, index) => preserved[Number(index)] || '');
+}
+
+function applyOutlineTextNormalization(items, options) {
+  if (!options?.chinese_quotes && !options?.strip_spaces) return items || [];
+  return (items || []).map((item) => ({
+    ...item,
+    title: applyTextNormalization(item.title, options),
+    description: applyTextNormalization(item.description, options),
+    content: applyTextNormalizationToMarkdown(item.content, options),
+    children: item.children?.length ? applyOutlineTextNormalization(item.children, options) : item.children,
+  }));
+}
+
+function outlineBookmarkId(nodeId) {
+  const raw = String(nodeId || '').trim();
+  if (!raw) return '';
+  return `outline-${raw.replace(/[^A-Za-z0-9_-]/g, '_')}`;
+}
+
+function splitExportTextParts(value) {
+  const text = String(value || '');
+  const parts = [];
+  const pattern = /\{\{page:outline-([^}]+)\}\}/g;
+  let lastIndex = 0;
+  let match = pattern.exec(text);
+  while (match) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', value: text.slice(lastIndex, match.index) });
+    }
+    parts.push({ type: 'pageRef', bookmarkId: outlineBookmarkId(match[1]) });
+    lastIndex = match.index + match[0].length;
+    match = pattern.exec(text);
+  }
+  if (lastIndex < text.length) {
+    parts.push({ type: 'text', value: text.slice(lastIndex) });
+  }
+  return parts;
+}
+
 function normalizeDocxColor(value, fallback = '536176') {
   const raw = String(value || '').trim().replace(/^#/, '');
   if (/^[0-9a-f]{6}$/i.test(raw)) return raw.toUpperCase();
@@ -272,16 +367,23 @@ function lineBreakRun() {
 }
 
 function textRunsWithBreaks(value, options = {}) {
-  const parts = String(value || '').split(/<br\s*\/?\s*>/gi);
   const runs = [];
-
-  parts.forEach((part, index) => {
-    if (index > 0) {
-      runs.push(lineBreakRun());
+  splitExportTextParts(value).forEach((segment) => {
+    if (segment.type === 'pageRef') {
+      if (segment.bookmarkId) {
+        runs.push(new PageReference(segment.bookmarkId, { hyperlink: true }));
+      }
+      return;
     }
-    if (part) {
-      runs.push(textRun(part, options));
-    }
+    const parts = String(segment.value || '').split(/<br\s*\/?\s*>/gi);
+    parts.forEach((part, index) => {
+      if (index > 0) {
+        runs.push(lineBreakRun());
+      }
+      if (part) {
+        runs.push(textRun(part, options));
+      }
+    });
   });
 
   return runs;
@@ -2022,7 +2124,27 @@ function buildOutlineHeadingParagraph(item, context, level, options = {}) {
     paraOptions.numbering = { reference: HEADING_NUMBERING_REFERENCE, level: Math.min(level - 1, 5) };
   }
 
-  return paragraph([textRun(displayTitle, runOptions)], paraOptions);
+  const bookmarkId = outlineBookmarkId(item.id);
+  const headingRun = textRun(displayTitle, runOptions);
+  return paragraph(
+    bookmarkId ? [new Bookmark({ id: bookmarkId, children: [headingRun] })] : [headingRun],
+    paraOptions,
+  );
+}
+
+function buildTableOfContentsChildren(context) {
+  if (!context.exportFormat?.include_table_of_contents) return [];
+  if (context.exportFormat?.heading_border?.enabled) {
+    addWarning(context, '当前章节框线会影响目录，建议先关闭框线。');
+  }
+  return [
+    paragraph([textRun('目录', { bold: true, size: 32 })], { alignment: AlignmentType.CENTER, after: 200 }),
+    new TableOfContents('目录', {
+      hyperlink: true,
+      headingStyleRange: '1-6',
+    }),
+    paragraph([textRun('')], { after: 200 }),
+  ];
 }
 
 async function addChapterFrameRows(rows, items, context, level = 1) {
@@ -2298,11 +2420,14 @@ async function buildDocxResult(payload, options = {}) {
   if (feasibility?.includeNotes) {
     children.push(...buildFeasibilityNotesParagraphs(payload, feasibility));
   }
+  children.push(...buildTableOfContentsChildren(context));
+
+  const outlineItems = applyOutlineTextNormalization(payload.outline || [], exportFormat?.text_normalization);
 
   reportProgress(context, 10, stats.mermaidCount
     ? `准备导出正文，并转换 ${stats.mermaidCount} 张 Mermaid 图。`
     : '准备导出正文。');
-  await addOutlineItems(children, payload.outline || [], context);
+  await addOutlineItems(children, outlineItems, context);
   if (feasibility?.includeAppendix) {
     children.push(...buildFeasibilityAppendixParagraphs(feasibility));
   }
@@ -2351,6 +2476,9 @@ async function buildDocxResult(payload, options = {}) {
     ...(firstPageDifferent ? { titlePage: true } : {}),
   };
   const doc = new Document({
+    features: {
+      updateFields: true,
+    },
     ...(numbering ? { numbering } : {}),
     styles: {
       default: {

--- a/client/electron/services/exportService.cjs
+++ b/client/electron/services/exportService.cjs
@@ -9,6 +9,10 @@ const { getMermaidCacheEntry, saveMermaidCacheImage } = require('../utils/mermai
 const { getGeneratedImagesDir, getImportedImagesDir } = require('../utils/paths.cjs');
 const { REMOTE_IMAGE_RETRY_ATTEMPTS, REMOTE_IMAGE_RETRY_DELAY_MS } = require('../utils/remoteImageRetry.cjs');
 const { renderMarkdownHtml } = require('../utils/renderMarkdownHtml.cjs');
+const {
+  applyTextNormalization,
+  applyTextNormalizationToMarkdown,
+} = require('../utils/textNormalization.cjs');
 const { getLocalImageRenderService } = require('./localImageRenderService.cjs');
 const {
   AlignmentType,
@@ -246,61 +250,6 @@ function formatExportTimestamp(date = new Date()) {
 
 function cleanText(value) {
   return String(value || '').replace(/[\x00-\x08\x0B\x0C\x0E-\x1F]/g, '');
-}
-
-function convertChineseQuotes(value) {
-  let result = '';
-  let doubleOpen = true;
-  let singleOpen = true;
-  const text = String(value || '');
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index];
-    if (char === '"') {
-      result += doubleOpen ? '“' : '”';
-      doubleOpen = !doubleOpen;
-      continue;
-    }
-    if (char === "'") {
-      const prev = text[index - 1] || '';
-      const next = text[index + 1] || '';
-      if (/[A-Za-z]/.test(prev) && /[A-Za-z]/.test(next)) {
-        result += char;
-        continue;
-      }
-      result += singleOpen ? '‘' : '’';
-      singleOpen = !singleOpen;
-      continue;
-    }
-    result += char;
-  }
-  return result;
-}
-
-function stripChineseSpaces(value) {
-  return String(value || '').replace(/([\u3400-\u9FFF\uF900-\uFAFF])[ \t]+(?=[\u3400-\u9FFF\uF900-\uFAFF])/g, '$1');
-}
-
-function applyTextNormalization(value, options) {
-  if (!options?.chinese_quotes && !options?.strip_spaces) return String(value || '');
-  let text = String(value || '');
-  if (options.chinese_quotes) text = convertChineseQuotes(text);
-  if (options.strip_spaces) text = stripChineseSpaces(text);
-  return text;
-}
-
-function applyTextNormalizationToMarkdown(markdown, options) {
-  if (!options?.chinese_quotes && !options?.strip_spaces) return String(markdown || '');
-  const preserved = [];
-  const protectedText = String(markdown || '')
-    .replace(/```[\s\S]*?```/g, (block) => {
-      preserved.push(block);
-      return `\0FENCE${preserved.length - 1}\0`;
-    })
-    .replace(/`[^`\n]+`/g, (block) => {
-      preserved.push(block);
-      return `\0FENCE${preserved.length - 1}\0`;
-    });
-  return applyTextNormalization(protectedText, options).replace(/\0FENCE(\d+)\0/g, (_, index) => preserved[Number(index)] || '');
 }
 
 function applyOutlineTextNormalization(items, options) {

--- a/client/electron/services/knowledgeBaseService.cjs
+++ b/client/electron/services/knowledgeBaseService.cjs
@@ -2284,6 +2284,10 @@ function createKnowledgeBaseService({ app, aiService, configStore, knowledgeBase
     readAnalysis(documentId) {
       return knowledgeBaseStore.readAnalysis(documentId, { debugLogPath: isDeveloperMode() ? getDebugLogPath(app, documentId) : '' });
     },
+
+    search(payload) {
+      return { results: knowledgeBaseStore.search(payload) };
+    },
   };
 }
 

--- a/client/electron/services/knowledgeBaseStore.cjs
+++ b/client/electron/services/knowledgeBaseStore.cjs
@@ -2,6 +2,12 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 const { getKnowledgeBaseDir } = require('../utils/paths.cjs');
+const {
+  removeDocumentSearch,
+  reindexDocumentSearch,
+  syncDocumentSearchMeta,
+  searchKnowledge,
+} = require('./knowledgeSearchIndex.cjs');
 
 const documentStatuses = ['pending', 'copying', 'converting', 'extracting', 'ready_for_matching', 'matching', 'recovering', 'analyzing', 'saving', 'success', 'error'];
 const documentStepKeys = ['copy_source', 'convert_markdown', 'build_blocks', 'extract_first_items', 'extract_supplement_items', 'merge_candidates', 'match_batches', 'recover_missing', 'save_result'];
@@ -239,6 +245,7 @@ function createKnowledgeBaseStore({ app, db }) {
         sort_order = excluded.sort_order,
         updated_at = excluded.updated_at
     `).run(values);
+    syncDocumentSearchMeta(db, values.document_id);
     return documentFromRow(values);
   }
 
@@ -323,13 +330,24 @@ function createKnowledgeBaseStore({ app, db }) {
   function deleteFolder(folderId) {
     const folder = db.prepare('SELECT * FROM knowledge_folders WHERE folder_id = ?').get(folderId);
     if (!folder) throw new Error('知识库文件夹不存在');
-    db.prepare('DELETE FROM knowledge_folders WHERE folder_id = ?').run(folderId);
+    const documentIds = db.prepare('SELECT document_id FROM knowledge_documents WHERE folder_id = ?').all(folderId).map((row) => row.document_id);
+    const transaction = db.transaction(() => {
+      for (const documentId of documentIds) {
+        removeDocumentSearch(db, documentId);
+      }
+      db.prepare('DELETE FROM knowledge_folders WHERE folder_id = ?').run(folderId);
+    });
+    transaction();
     return folderFromRow(folder);
   }
 
   function deleteDocument(documentId) {
     const document = getDocument(documentId);
-    db.prepare('DELETE FROM knowledge_documents WHERE document_id = ?').run(documentId);
+    const transaction = db.transaction(() => {
+      removeDocumentSearch(db, documentId);
+      db.prepare('DELETE FROM knowledge_documents WHERE document_id = ?').run(documentId);
+    });
+    transaction();
     return document;
   }
 
@@ -435,6 +453,7 @@ function createKnowledgeBaseStore({ app, db }) {
       resequenceDocumentIds(targetFolderId, nextTargetIds, timestamp);
     });
     transaction();
+    syncDocumentSearchMeta(db, documentId);
     return {
       ...document,
       folder_id: targetFolderId,
@@ -497,6 +516,9 @@ function createKnowledgeBaseStore({ app, db }) {
       RETURNING *
     `).get(values);
     if (!row) throw new Error('知识库文档不存在');
+    if (hasOwn(partial, 'file_name') || hasOwn(partial, 'fileName') || hasOwn(partial, 'folder_id') || hasOwn(partial, 'folderId')) {
+      syncDocumentSearchMeta(db, documentId);
+    }
     return documentFromRow(row);
   }
 
@@ -553,6 +575,7 @@ function createKnowledgeBaseStore({ app, db }) {
       });
     });
     writeDocumentUpdate(documentId, { block_count: Array.isArray(blocks) ? blocks.length : 0, filtered_block_count: Array.isArray(filteredBlocks) ? filteredBlocks.length : 0 });
+    reindexDocumentSearch(db, documentId);
   }
 
   const saveBlocksTransaction = db.transaction(replaceBlocks);
@@ -733,6 +756,7 @@ function createKnowledgeBaseStore({ app, db }) {
         discarded_block_count: Number((report || matchResult?.report)?.discarded_blocks_count || 0),
         system_discarded_after_retry_count: Number((report || matchResult?.report)?.system_discarded_after_retry_count || 0),
       });
+      reindexDocumentSearch(db, documentId);
     });
     transaction();
   }
@@ -950,6 +974,7 @@ function createKnowledgeBaseStore({ app, db }) {
         Object.assign(resetFields, { item_count: 0, discarded_block_count: 0, system_discarded_after_retry_count: 0 });
       }
       writeDocumentUpdate(documentId, resetFields);
+      reindexDocumentSearch(db, documentId);
     });
     transaction();
   }
@@ -1135,6 +1160,7 @@ function createKnowledgeBaseStore({ app, db }) {
     readItems,
     readAnalysis,
     getOutlineReferences,
+    search: (payload) => searchKnowledge(db, payload),
     resolvePath,
   };
 }

--- a/client/electron/services/knowledgeSearchIndex.cjs
+++ b/client/electron/services/knowledgeSearchIndex.cjs
@@ -1,0 +1,357 @@
+const DEFAULT_SEARCH_LIMIT = 40;
+const MAX_SEARCH_LIMIT = 100;
+
+function tableExists(db, name) {
+  return Boolean(db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(name));
+}
+
+function createFtsTable(db) {
+  try {
+    db.exec(`
+      CREATE VIRTUAL TABLE knowledge_search_fts USING fts5(
+        file_name,
+        title,
+        resume,
+        body,
+        content='knowledge_search_rows',
+        content_rowid='id',
+        tokenize='trigram'
+      )
+    `);
+    return 'trigram';
+  } catch {
+    db.exec(`
+      CREATE VIRTUAL TABLE knowledge_search_fts USING fts5(
+        file_name,
+        title,
+        resume,
+        body,
+        content='knowledge_search_rows',
+        content_rowid='id',
+        tokenize='unicode61 remove_diacritics 2'
+      )
+    `);
+    return 'unicode61';
+  }
+}
+
+function createKnowledgeSearchSchema(db) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS knowledge_search_rows (
+      id INTEGER PRIMARY KEY,
+      entity_key TEXT NOT NULL UNIQUE,
+      entity_type TEXT NOT NULL,
+      document_id TEXT NOT NULL,
+      folder_id TEXT NOT NULL DEFAULT '',
+      item_id TEXT NOT NULL DEFAULT '',
+      block_id TEXT NOT NULL DEFAULT '',
+      file_name TEXT NOT NULL DEFAULT '',
+      title TEXT NOT NULL DEFAULT '',
+      resume TEXT NOT NULL DEFAULT '',
+      body TEXT NOT NULL DEFAULT ''
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_knowledge_search_rows_document
+    ON knowledge_search_rows(document_id);
+
+    CREATE INDEX IF NOT EXISTS idx_knowledge_search_rows_folder
+    ON knowledge_search_rows(folder_id, entity_type);
+  `);
+
+  const createdFts = !tableExists(db, 'knowledge_search_fts');
+  if (createdFts) {
+    createFtsTable(db);
+  }
+
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS knowledge_search_rows_ai AFTER INSERT ON knowledge_search_rows BEGIN
+      INSERT INTO knowledge_search_fts(rowid, file_name, title, resume, body)
+      VALUES (new.id, new.file_name, new.title, new.resume, new.body);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS knowledge_search_rows_ad AFTER DELETE ON knowledge_search_rows BEGIN
+      INSERT INTO knowledge_search_fts(knowledge_search_fts, rowid, file_name, title, resume, body)
+      VALUES('delete', old.id, old.file_name, old.title, old.resume, old.body);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS knowledge_search_rows_au AFTER UPDATE ON knowledge_search_rows BEGIN
+      INSERT INTO knowledge_search_fts(knowledge_search_fts, rowid, file_name, title, resume, body)
+      VALUES('delete', old.id, old.file_name, old.title, old.resume, old.body);
+      INSERT INTO knowledge_search_fts(rowid, file_name, title, resume, body)
+      VALUES (new.id, new.file_name, new.title, new.resume, new.body);
+    END;
+  `);
+  if (createdFts) {
+    const indexed = Number(db.prepare('SELECT COUNT(*) AS n FROM knowledge_search_rows').get()?.n || 0);
+    if (indexed > 0) {
+      db.exec("INSERT INTO knowledge_search_fts(knowledge_search_fts) VALUES('rebuild')");
+    } else {
+      backfillKnowledgeSearch(db);
+    }
+  } else {
+    backfillKnowledgeSearch(db);
+  }
+}
+
+function parseHeadingPath(value) {
+  if (!value) return '';
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map((item) => String(item || '').trim()).filter(Boolean).join(' / ') : '';
+  } catch {
+    return '';
+  }
+}
+
+function insertSearchRow(db, row) {
+  db.prepare(`
+    INSERT INTO knowledge_search_rows (
+      entity_key, entity_type, document_id, folder_id, item_id, block_id, file_name, title, resume, body
+    ) VALUES (
+      @entity_key, @entity_type, @document_id, @folder_id, @item_id, @block_id, @file_name, @title, @resume, @body
+    )
+  `).run({
+    entity_key: row.entity_key,
+    entity_type: row.entity_type,
+    document_id: row.document_id,
+    folder_id: row.folder_id || '',
+    item_id: row.item_id || '',
+    block_id: row.block_id || '',
+    file_name: row.file_name || '',
+    title: row.title || '',
+    resume: row.resume || '',
+    body: row.body || '',
+  });
+}
+
+function removeDocumentSearch(db, documentId) {
+  if (!tableExists(db, 'knowledge_search_rows')) return;
+  db.prepare('DELETE FROM knowledge_search_rows WHERE document_id = ?').run(documentId);
+}
+
+function reindexDocumentSearch(db, documentId) {
+  if (!tableExists(db, 'knowledge_search_rows') || !tableExists(db, 'knowledge_documents')) return;
+  const document = db.prepare(`
+    SELECT document_id, folder_id, file_name
+    FROM knowledge_documents
+    WHERE document_id = ?
+  `).get(documentId);
+  removeDocumentSearch(db, documentId);
+  if (!document) return;
+
+  insertSearchRow(db, {
+    entity_key: `document:${document.document_id}`,
+    entity_type: 'document',
+    document_id: document.document_id,
+    folder_id: document.folder_id,
+    file_name: document.file_name,
+    title: document.file_name,
+  });
+
+  const items = db.prepare(`
+    SELECT item_id, title, resume, content
+    FROM knowledge_items
+    WHERE document_id = ?
+    ORDER BY sort_order ASC, id ASC
+  `).all(documentId);
+  for (const item of items) {
+    insertSearchRow(db, {
+      entity_key: `item:${document.document_id}:${item.item_id}`,
+      entity_type: 'item',
+      document_id: document.document_id,
+      folder_id: document.folder_id,
+      item_id: item.item_id,
+      file_name: document.file_name,
+      title: item.title || '',
+      resume: item.resume || '',
+      body: item.content || '',
+    });
+  }
+
+  const blocks = db.prepare(`
+    SELECT block_id, heading_path_json, content
+    FROM knowledge_blocks
+    WHERE document_id = ? AND is_filtered = 0
+    ORDER BY sort_order ASC, id ASC
+  `).all(documentId);
+  for (const block of blocks) {
+    insertSearchRow(db, {
+      entity_key: `block:${document.document_id}:${block.block_id}`,
+      entity_type: 'block',
+      document_id: document.document_id,
+      folder_id: document.folder_id,
+      block_id: block.block_id,
+      file_name: document.file_name,
+      title: parseHeadingPath(block.heading_path_json) || block.block_id,
+      body: block.content || '',
+    });
+  }
+}
+
+function syncDocumentSearchMeta(db, documentId) {
+  if (!tableExists(db, 'knowledge_search_rows') || !tableExists(db, 'knowledge_documents')) return;
+  const document = db.prepare(`
+    SELECT document_id, folder_id, file_name
+    FROM knowledge_documents
+    WHERE document_id = ?
+  `).get(documentId);
+  if (!document) {
+    removeDocumentSearch(db, documentId);
+    return;
+  }
+
+  const existing = db.prepare(`
+    SELECT id FROM knowledge_search_rows
+    WHERE entity_type = 'document' AND document_id = ?
+  `).get(documentId);
+  if (!existing) {
+    reindexDocumentSearch(db, documentId);
+    return;
+  }
+
+  db.prepare(`
+    UPDATE knowledge_search_rows
+    SET folder_id = ?, file_name = ?, title = CASE WHEN entity_type = 'document' THEN ? ELSE title END
+    WHERE document_id = ?
+  `).run(document.folder_id, document.file_name, document.file_name, documentId);
+}
+
+function backfillKnowledgeSearch(db, options = {}) {
+  if (!tableExists(db, 'knowledge_documents') || !tableExists(db, 'knowledge_search_rows')) return;
+  const force = Boolean(options.force);
+  if (!force) {
+    const indexed = Number(db.prepare('SELECT COUNT(*) AS n FROM knowledge_search_rows').get()?.n || 0);
+    if (indexed > 0) return;
+  }
+  db.prepare('DELETE FROM knowledge_search_rows').run();
+  const documentIds = db.prepare('SELECT document_id FROM knowledge_documents').all().map((row) => row.document_id);
+  for (const documentId of documentIds) {
+    reindexDocumentSearch(db, documentId);
+  }
+}
+
+function normalizeSearchLimit(value) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return DEFAULT_SEARCH_LIMIT;
+  return Math.max(1, Math.min(MAX_SEARCH_LIMIT, Math.floor(number)));
+}
+
+function escapeLikeQuery(value) {
+  return String(value || '').replace(/([\\%_])/g, '\\$1');
+}
+
+function escapeFtsQuery(value) {
+  return `"${String(value || '').replace(/"/g, '""')}"`;
+}
+
+function buildSnippet(text, query, max = 80) {
+  const source = String(text || '').replace(/\s+/g, ' ').trim();
+  if (!source) return '';
+  const keyword = String(query || '').trim();
+  if (!keyword) return source.length > max ? `${source.slice(0, max)}…` : source;
+  const index = source.toLowerCase().indexOf(keyword.toLowerCase());
+  if (index < 0) return source.length > max ? `${source.slice(0, max)}…` : source;
+  const start = Math.max(0, index - 16);
+  const end = Math.min(source.length, index + keyword.length + 48);
+  return `${start > 0 ? '…' : ''}${source.slice(start, end)}${end < source.length ? '…' : ''}`;
+}
+
+function mapSearchRow(row, query) {
+  return {
+    type: row.entity_type,
+    documentId: row.document_id,
+    folderId: row.folder_id,
+    folderName: row.folder_name || '',
+    fileName: row.file_name || '',
+    itemId: row.item_id || undefined,
+    blockId: row.block_id || undefined,
+    title: row.title || row.file_name || '',
+    snippet: String(row.snippet || '').trim() || buildSnippet(row.body || row.resume || row.title || row.file_name, query),
+  };
+}
+
+function likeSearch(db, query, folderId, limit) {
+  const pattern = `%${escapeLikeQuery(query)}%`;
+  const rows = db.prepare(`
+    SELECT
+      r.entity_type,
+      r.document_id,
+      r.folder_id,
+      r.item_id,
+      r.block_id,
+      r.file_name,
+      r.title,
+      r.resume,
+      r.body,
+      COALESCE(f.name, '') AS folder_name
+    FROM knowledge_search_rows r
+    LEFT JOIN knowledge_folders f ON f.folder_id = r.folder_id
+    WHERE (
+      r.file_name LIKE ? ESCAPE '\\'
+      OR r.title LIKE ? ESCAPE '\\'
+      OR r.resume LIKE ? ESCAPE '\\'
+      OR r.body LIKE ? ESCAPE '\\'
+    )
+      AND (? = '' OR r.folder_id = ?)
+    ORDER BY CASE r.entity_type WHEN 'document' THEN 0 WHEN 'item' THEN 1 ELSE 2 END, r.id ASC
+    LIMIT ?
+  `).all(pattern, pattern, pattern, pattern, folderId, folderId, limit);
+  return rows.map((row) => mapSearchRow(row, query));
+}
+
+function ftsSearch(db, query, folderId, limit) {
+  const rows = db.prepare(`
+    SELECT
+      r.entity_type,
+      r.document_id,
+      r.folder_id,
+      r.item_id,
+      r.block_id,
+      r.file_name,
+      r.title,
+      r.resume,
+      r.body,
+      COALESCE(f.name, '') AS folder_name,
+      snippet(knowledge_search_fts, 3, '', '', '…', 12) AS snippet
+    FROM knowledge_search_fts
+    JOIN knowledge_search_rows r ON r.id = knowledge_search_fts.rowid
+    LEFT JOIN knowledge_folders f ON f.folder_id = r.folder_id
+    WHERE knowledge_search_fts MATCH ?
+      AND (? = '' OR r.folder_id = ?)
+    ORDER BY bm25(knowledge_search_fts), CASE r.entity_type WHEN 'document' THEN 0 WHEN 'item' THEN 1 ELSE 2 END
+    LIMIT ?
+  `).all(escapeFtsQuery(query), folderId, folderId, limit);
+  return rows.map((row) => mapSearchRow(row, query));
+}
+
+function searchKnowledge(db, payload = {}) {
+  const query = String(payload.query || '').trim();
+  if (!query) return [];
+  if (!tableExists(db, 'knowledge_search_rows')) return [];
+  const folderId = String(payload.folderId || '').trim();
+  const limit = normalizeSearchLimit(payload.limit);
+  if (query.length < 3 || !tableExists(db, 'knowledge_search_fts')) {
+    return likeSearch(db, query, folderId, limit);
+  }
+  try {
+    const results = ftsSearch(db, query, folderId, limit);
+    return results.length ? results : likeSearch(db, query, folderId, limit);
+  } catch {
+    return likeSearch(db, query, folderId, limit);
+  }
+}
+
+module.exports = {
+  createKnowledgeSearchSchema,
+  backfillKnowledgeSearch,
+  removeDocumentSearch,
+  reindexDocumentSearch,
+  syncDocumentSearchMeta,
+  searchKnowledge,
+  _internals: {
+    escapeLikeQuery,
+    escapeFtsQuery,
+    buildSnippet,
+    normalizeSearchLimit,
+  },
+};

--- a/client/electron/services/knowledgeSearchIndex.electron-test.cjs
+++ b/client/electron/services/knowledgeSearchIndex.electron-test.cjs
@@ -1,0 +1,124 @@
+const { app } = require('electron');
+const Database = require('better-sqlite3');
+const {
+  createKnowledgeSearchSchema,
+  backfillKnowledgeSearch,
+  reindexDocumentSearch,
+  removeDocumentSearch,
+  searchKnowledge,
+} = require('./knowledgeSearchIndex.cjs');
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function seedKnowledge(db) {
+  const now = new Date().toISOString();
+  db.exec(`
+    CREATE TABLE knowledge_folders (
+      folder_id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE knowledge_documents (
+      document_id TEXT PRIMARY KEY,
+      folder_id TEXT NOT NULL,
+      file_name TEXT NOT NULL
+    );
+    CREATE TABLE knowledge_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      document_id TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      resume TEXT NOT NULL,
+      content TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE knowledge_blocks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      document_id TEXT NOT NULL,
+      block_id TEXT NOT NULL,
+      heading_path_json TEXT,
+      content TEXT NOT NULL,
+      is_filtered INTEGER NOT NULL DEFAULT 0,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  db.prepare('INSERT INTO knowledge_folders VALUES (?, ?, 0, ?, ?)').run('folder-a', '历史方案', now, now);
+  db.prepare('INSERT INTO knowledge_folders VALUES (?, ?, 1, ?, ?)').run('folder-b', '其他资料', now, now);
+  db.prepare('INSERT INTO knowledge_documents VALUES (?, ?, ?)').run('doc-a', 'folder-a', '智慧园区实施方案.docx');
+  db.prepare('INSERT INTO knowledge_documents VALUES (?, ?, ?)').run('doc-b', 'folder-b', '无关报价表.xlsx');
+  db.prepare('INSERT INTO knowledge_items (document_id, item_id, title, resume, content, sort_order) VALUES (?, ?, ?, ?, ?, 0)')
+    .run('doc-a', 'K000001', '项目管理组织', '项目经理职责', '项目经理负责现场协调和进度管理。');
+  db.prepare('INSERT INTO knowledge_blocks (document_id, block_id, heading_path_json, content, is_filtered, sort_order) VALUES (?, ?, ?, ?, 0, 0)')
+    .run('doc-a', 'P000001', '["实施保障"]', '应急预案应覆盖停电和网络中断。');
+  db.prepare('INSERT INTO knowledge_blocks (document_id, block_id, heading_path_json, content, is_filtered, sort_order) VALUES (?, ?, ?, ?, 1, 0)')
+    .run('doc-a', 'F000001', '[]', '这段被筛除的应急预案不应被检索到。');
+}
+
+function runTest() {
+  const db = new Database(':memory:');
+  try {
+    seedKnowledge(db);
+    createKnowledgeSearchSchema(db);
+    backfillKnowledgeSearch(db, { force: true });
+
+    assert(searchKnowledge(db, { query: '' }).length === 0, 'empty query should return no results');
+
+    const itemHits = searchKnowledge(db, { query: '项目管理' });
+    assert(itemHits.some((hit) => hit.type === 'item' && hit.itemId === 'K000001'), 'should find knowledge item by title');
+    assert(itemHits.some((hit) => hit.documentId === 'doc-a'), 'item hit should point to source document');
+
+    const blockHits = searchKnowledge(db, { query: '应急预案' });
+    assert(blockHits.some((hit) => hit.type === 'block' && hit.blockId === 'P000001'), 'should find unfiltered block');
+    assert(!blockHits.some((hit) => hit.blockId === 'F000001'), 'filtered blocks must stay out of search');
+
+    const folderHits = searchKnowledge(db, { query: '项目管理', folderId: 'folder-b' });
+    assert(folderHits.length === 0, 'folder filter should exclude other folders');
+
+    const fileHits = searchKnowledge(db, { query: '智慧园区' });
+    assert(fileHits.some((hit) => hit.type === 'document' && hit.documentId === 'doc-a'), 'should find document by file name');
+
+    removeDocumentSearch(db, 'doc-a');
+    assert(!searchKnowledge(db, { query: '项目管理' }).some((hit) => hit.documentId === 'doc-a'), 'deleted document should leave the index');
+    reindexDocumentSearch(db, 'doc-a');
+    assert(searchKnowledge(db, { query: '项目管理' }).some((hit) => hit.documentId === 'doc-a'), 'reindex should restore document hits');
+
+    console.log('[knowledge-search] FTS index, folder filter, and filtered-block exclusion passed.');
+  } finally {
+    db.close();
+  }
+}
+
+function exitWithCode(code) {
+  if (app?.isReady?.()) {
+    app.exit(code);
+    return;
+  }
+  process.exit(code);
+}
+
+function main() {
+  try {
+    runTest();
+    exitWithCode(0);
+  } catch (error) {
+    console.error('[knowledge-search] test failed.');
+    console.error(error?.stack || error?.message || String(error));
+    exitWithCode(1);
+  }
+}
+
+if (app?.whenReady) {
+  app.whenReady().then(main, (error) => {
+    console.error('[knowledge-search] Electron app failed to become ready.');
+    console.error(error?.stack || error?.message || String(error));
+    exitWithCode(1);
+  });
+} else {
+  main();
+}

--- a/client/electron/services/knowledgeSearchIndex.test.cjs
+++ b/client/electron/services/knowledgeSearchIndex.test.cjs
@@ -1,0 +1,21 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { _internals } = require('./knowledgeSearchIndex.cjs');
+
+describe('knowledgeSearchIndex helpers', () => {
+  it('escapes LIKE and FTS query characters', () => {
+    assert.equal(_internals.escapeLikeQuery('50%_off'), '50\\%\\_off');
+    assert.equal(_internals.escapeFtsQuery('项目"管理'), '"项目""管理"');
+  });
+
+  it('builds a snippet around the keyword', () => {
+    const snippet = _internals.buildSnippet('项目经理负责现场协调和进度管理。', '现场协调', 80);
+    assert.match(snippet, /现场协调/);
+  });
+
+  it('clamps search limit', () => {
+    assert.equal(_internals.normalizeSearchLimit(0), 1);
+    assert.equal(_internals.normalizeSearchLimit(999), 100);
+    assert.equal(_internals.normalizeSearchLimit('x'), 40);
+  });
+});

--- a/client/electron/services/outlineImportService.cjs
+++ b/client/electron/services/outlineImportService.cjs
@@ -1,0 +1,247 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadElectron() {
+  return require('electron');
+}
+
+const MAX_OUTLINE_LEVEL = 6;
+const POINT_TO_POINT_PATTERN = /应答表|偏离表|点对点/;
+const TEMPLATE_FILL_PATTERN = /格式|模板|一览表|报价表/;
+const HEADING_NUMBER_PATTERN = /^(?:第[一二三四五六七八九十百千零0-9]+[章节条款部分篇]|[（(][一二三四五六七八九十百千零0-9]+[)）]|[一二三四五六七八九十百千]+、|[0-9]+(?:\.[0-9]+)*[、.．)]?\s+)/;
+
+function inferContentMode(title) {
+  const text = String(title || '');
+  if (POINT_TO_POINT_PATTERN.test(text)) return 'point-to-point';
+  if (TEMPLATE_FILL_PATTERN.test(text)) return 'template-fill';
+  return 'ai-generate';
+}
+
+function stripHeadingNumber(title) {
+  let next = String(title || '').replace(/\s+/g, ' ').trim();
+  const stripped = next.replace(HEADING_NUMBER_PATTERN, '').trim();
+  return stripped || next;
+}
+
+function isFenceLine(line) {
+  return /^```/.test(String(line || '').trim());
+}
+
+function extractMarkdownHeadings(markdown) {
+  const lines = String(markdown || '').replace(/\r\n/g, '\n').split('\n');
+  const headings = [];
+  let inFence = false;
+  let truncated = false;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (isFenceLine(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const atx = /^(#{1,})(\s+.+?)\s*#*\s*$/.exec(line);
+    if (atx) {
+      const rawLevel = atx[1].length;
+      if (rawLevel > MAX_OUTLINE_LEVEL) truncated = true;
+      headings.push({
+        level: Math.min(rawLevel, MAX_OUTLINE_LEVEL),
+        title: stripHeadingNumber(atx[2]),
+      });
+      continue;
+    }
+
+    const nextLine = lines[index + 1] || '';
+    if (line.trim() && /^=+\s*$/.test(nextLine)) {
+      headings.push({ level: 1, title: stripHeadingNumber(line) });
+      index += 1;
+      continue;
+    }
+    if (line.trim() && /^-+\s*$/.test(nextLine)) {
+      headings.push({ level: 2, title: stripHeadingNumber(line) });
+      index += 1;
+    }
+  }
+
+  return { headings: headings.filter((item) => item.title), truncated };
+}
+
+function renumberImportedOutline(items, prefix = '') {
+  return (items || []).map((item, index) => {
+    const id = prefix ? `${prefix}.${index + 1}` : String(index + 1);
+    const children = Array.isArray(item.children) && item.children.length
+      ? renumberImportedOutline(item.children, id)
+      : undefined;
+    const next = {
+      id,
+      title: String(item.title || '').trim(),
+      description: String(item.description || '').trim(),
+    };
+    if (children?.length) {
+      next.children = children;
+    } else {
+      next.content_mode = item.content_mode || inferContentMode(item.title);
+    }
+    return next;
+  });
+}
+
+function buildOutlineFromHeadings(headings) {
+  const roots = [];
+  const stack = [];
+
+  for (const heading of headings) {
+    const node = {
+      title: heading.title,
+      description: '',
+      content_mode: inferContentMode(heading.title),
+      children: [],
+    };
+    while (stack.length && stack[stack.length - 1].level >= heading.level) {
+      stack.pop();
+    }
+    if (!stack.length) {
+      roots.push(node);
+    } else {
+      stack[stack.length - 1].node.children.push(node);
+    }
+    stack.push({ level: heading.level, node });
+  }
+
+  const pruneEmptyChildren = (items) => items.map((item) => {
+    const children = pruneEmptyChildren(item.children || []);
+    if (children.length) {
+      return { title: item.title, description: item.description, children };
+    }
+    return { title: item.title, description: item.description, content_mode: item.content_mode };
+  });
+
+  return renumberImportedOutline(pruneEmptyChildren(roots));
+}
+
+function parseOutlineFromMarkdown(markdown) {
+  const { headings, truncated } = extractMarkdownHeadings(markdown);
+  if (!headings.length) {
+    return {
+      success: false,
+      message: '没有识别到可用标题。请使用 Word 标题样式或 Markdown 标题后再导入。',
+      outline: [],
+      warnings: [],
+      truncated: false,
+    };
+  }
+
+  const outline = buildOutlineFromHeadings(headings);
+  const warnings = [];
+  if (truncated) {
+    warnings.push('超过 6 级的标题已截断为第 6 级。');
+  }
+  return {
+    success: true,
+    outline,
+    warnings,
+    truncated,
+  };
+}
+
+function normalizeProvidedFilePaths(filePaths) {
+  if (!Array.isArray(filePaths)) return [];
+  return filePaths.map((item) => String(item || '').trim()).filter(Boolean);
+}
+
+function sanitizeFilename(name) {
+  return String(name || '')
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80) || '项目简报';
+}
+
+async function exportMarkdownFile({ content, defaultFileName, title } = {}) {
+  const markdown = String(content || '');
+  if (!markdown.trim()) {
+    return { success: false, message: '没有可导出的 Markdown 内容' };
+  }
+  const { app, dialog } = loadElectron();
+  const defaultDir = app?.getPath ? app.getPath('downloads') : process.env.USERPROFILE || process.cwd();
+  const fileName = sanitizeFilename(defaultFileName || '项目简报.md');
+  const result = await dialog.showSaveDialog({
+    title: title || '导出 Markdown',
+    defaultPath: path.join(defaultDir, fileName.endsWith('.md') ? fileName : `${fileName}.md`),
+    filters: [{ name: 'Markdown', extensions: ['md'] }],
+  });
+  if (result.canceled || !result.filePath) {
+    return { success: false, canceled: true, message: '已取消导出' };
+  }
+  const outputPath = result.filePath.endsWith('.md') ? result.filePath : `${result.filePath}.md`;
+  fs.writeFileSync(outputPath, markdown, 'utf8');
+  return { success: true, path: outputPath, message: 'Markdown 已导出。' };
+}
+
+function createOutlineImportService({ configStore } = {}) {
+  async function importOutlineDocument(filePaths) {
+    const { parseDocumentWithConfig } = require('./fileService.cjs');
+    const { app, dialog } = loadElectron();
+    const config = configStore ? configStore.load() : { components: { file_parser: { provider: 'local' } } };
+    let selectedPaths = normalizeProvidedFilePaths(filePaths);
+    if (selectedPaths.length > 1) selectedPaths = selectedPaths.slice(0, 1);
+
+    if (!selectedPaths.length) {
+      const result = await dialog.showOpenDialog({
+        title: '选择目录文件',
+        properties: ['openFile'],
+        filters: [
+          { name: 'Word / Markdown', extensions: ['docx', 'doc', 'md', 'markdown'] },
+          { name: '所有文件', extensions: ['*'] },
+        ],
+      });
+      if (result.canceled || !result.filePaths.length) {
+        return { success: false, canceled: true, message: '已取消选择' };
+      }
+      selectedPaths = result.filePaths;
+    }
+
+    const filePath = selectedPaths[0];
+    const fileName = path.basename(filePath);
+    let markdown = '';
+    try {
+      markdown = (await parseDocumentWithConfig(app, filePath, config, {
+        assetScope: 'outline-import',
+        preserveImages: false,
+      })).trim();
+    } catch (error) {
+      return { success: false, message: error.message || `解析 ${fileName} 失败`, fileName };
+    }
+
+    if (!markdown) {
+      return { success: false, message: `${fileName} 未提取到有效内容`, fileName };
+    }
+
+    const parsed = parseOutlineFromMarkdown(markdown);
+    if (!parsed.success) {
+      return { ...parsed, fileName };
+    }
+
+    return {
+      success: true,
+      fileName,
+      outline: parsed.outline,
+      warnings: parsed.warnings,
+      truncated: parsed.truncated,
+      message: `已从 ${fileName} 识别 ${parsed.outline.length} 个一级目录`,
+    };
+  }
+
+  return {
+    importOutlineDocument,
+    exportMarkdownFile,
+  };
+}
+
+module.exports = {
+  createOutlineImportService,
+  inferContentMode,
+  parseOutlineFromMarkdown,
+  stripHeadingNumber,
+};

--- a/client/electron/services/outlineImportService.test.cjs
+++ b/client/electron/services/outlineImportService.test.cjs
@@ -1,0 +1,55 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { inferContentMode, parseOutlineFromMarkdown, stripHeadingNumber } = require('./outlineImportService.cjs');
+
+describe('outlineImportService', () => {
+  it('strips heading numbers and infers leaf modes', () => {
+    assert.equal(stripHeadingNumber('1.1 实施方案'), '实施方案');
+    assert.equal(stripHeadingNumber('一、项目概况'), '项目概况');
+    assert.equal(inferContentMode('技术偏差点对点应答表'), 'point-to-point');
+    assert.equal(inferContentMode('商务偏离表'), 'point-to-point');
+    assert.equal(inferContentMode('响应文件格式'), 'template-fill');
+    assert.equal(inferContentMode('分项报价表'), 'template-fill');
+    assert.equal(inferContentMode('实施方案'), 'ai-generate');
+  });
+
+  it('builds a tree from ATX and Setext headings', () => {
+    const markdown = [
+      '# 1 项目概述',
+      '',
+      '概述正文',
+      '',
+      '技术方案',
+      '=======',
+      '',
+      '## 2.1 总体方案',
+      '### 2.1.1 架构设计',
+      '## 2.2 点对点应答表',
+      '## 2.3 投标格式一览表',
+      '',
+      '# 附录标题',
+    ].join('\n');
+
+    const result = parseOutlineFromMarkdown(markdown);
+    assert.equal(result.success, true);
+    assert.equal(result.outline.length, 3);
+    assert.equal(result.outline[0].id, '1');
+    assert.equal(result.outline[0].title, '项目概述');
+    assert.equal(result.outline[0].content_mode, 'ai-generate');
+    assert.equal(result.outline[1].id, '2');
+    assert.equal(result.outline[1].title, '技术方案');
+    assert.equal(result.outline[1].children[0].id, '2.1');
+    assert.equal(result.outline[1].children[0].children[0].id, '2.1.1');
+    assert.equal(result.outline[1].children[1].content_mode, 'point-to-point');
+    assert.equal(result.outline[1].children[2].content_mode, 'template-fill');
+    assert.equal(result.outline[2].title, '附录标题');
+  });
+
+  it('reports missing headings and truncated deep levels', () => {
+    assert.equal(parseOutlineFromMarkdown('只有正文没有标题').success, false);
+    const deep = parseOutlineFromMarkdown('####### 超深标题\n# 正常标题');
+    assert.equal(deep.success, true);
+    assert.equal(deep.truncated, true);
+    assert.match(deep.warnings[0], /6 级/);
+  });
+});

--- a/client/electron/services/pointToPointTask.cjs
+++ b/client/electron/services/pointToPointTask.cjs
@@ -1,0 +1,154 @@
+function singleLine(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function collectLeaves(items) {
+  const leaves = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    if (item?.children?.length) {
+      leaves.push(...collectLeaves(item.children));
+    } else {
+      leaves.push(item);
+    }
+  }
+  return leaves;
+}
+
+function summarizeContent(content, limit = 240) {
+  const text = String(content || '').replace(/\s+/g, ' ').trim();
+  if (!text) return '待正文';
+  return text.length > limit ? `${text.slice(0, limit)}…` : text;
+}
+
+function buildOutlineCatalog(items) {
+  return collectLeaves(items).map((item) => {
+    const hasContent = Boolean(String(item?.content || '').trim());
+    return `- ${item.id} ${item.title}｜模式：${item.content_mode || 'ai-generate'}｜正文：${hasContent ? summarizeContent(item.content) : '待正文'}`;
+  }).join('\n');
+}
+
+function updateOutlineContent(items, nodeId, content) {
+  return (items || []).map((item) => {
+    if (item.id === nodeId) {
+      return { ...item, content };
+    }
+    return item.children?.length
+      ? { ...item, children: updateOutlineContent(item.children, nodeId, content) }
+      : item;
+  });
+}
+
+function buildPointToPointPrompt({ item, techRequirements, businessScoring, outlineCatalog }) {
+  return `任务：为目录小节“${singleLine(item.title)}”生成点对点应答表。
+
+章节说明：
+${String(item.description || '').trim() || '无'}
+
+固定输出 Markdown 表格，表头必须且只能是：
+| 条款 | 招标要求 | 响应章节 | 响应结论 | 页码 |
+
+填写规则：
+1. “条款”写评分项或技术要求名称。
+2. “招标要求”尽量保留招标原文要点，不要编造。
+3. “响应章节”写目录编号加标题，例如“3.2 实施方案”。
+4. “页码”必须写成占位 {{page:outline-节点id}}，节点id 使用当前目录树中的真实 id，例如 {{page:outline-3.2}}。
+5. 如果对应章节还没有正文，响应结论写“待正文”，页码仍保留占位。
+6. 只输出一张表，不要解释过程。
+
+技术评分要求：
+${String(techRequirements || '').trim() || '未提供'}
+
+商务评分要求：
+${String(businessScoring || '').trim() || '未提供'}
+
+当前目录与正文摘要：
+${outlineCatalog || '暂无目录'}`;
+}
+
+async function runPointToPointTask({
+  aiService,
+  workspaceStore,
+  updateTask,
+  checkpointTask,
+  payload,
+}) {
+  const plan = workspaceStore.loadTechnicalPlan() || {};
+  const outline = plan.outlineData?.outline || [];
+  const requestedIds = new Set((Array.isArray(payload?.nodeIds) ? payload.nodeIds : [])
+    .map((id) => String(id || '').trim())
+    .filter(Boolean));
+  const leaves = collectLeaves(outline)
+    .filter((item) => item.content_mode === 'point-to-point')
+    .filter((item) => !requestedIds.size || requestedIds.has(item.id));
+  if (!leaves.length) {
+    throw new Error('当前目录没有需要生成的点对点应答表小节');
+  }
+
+  const techRequirements = plan.techRequirements
+    || (plan.bidAnalysisTasks?.techRequirements?.status === 'success' ? plan.bidAnalysisTasks.techRequirements.content : '');
+  const businessScoring = plan.bidAnalysisTasks?.businessScoring?.status === 'success'
+    ? plan.bidAnalysisTasks.businessScoring.content
+    : '';
+  const outlineCatalog = buildOutlineCatalog(outline);
+
+  let currentOutline = outline;
+  let completed = 0;
+  checkpointTask({
+    status: 'running',
+    progress: 0,
+    logs: [`开始生成 ${leaves.length} 个点对点应答表。`],
+  });
+
+  for (const item of leaves) {
+    checkpointTask({
+      status: 'running',
+      progress: Math.round((completed / leaves.length) * 100),
+      logs: [`正在生成 ${item.id} ${item.title}`],
+    });
+    const content = String(await aiService.chat({
+      messages: [
+        { role: 'system', content: '你是投标点对点应答表助手。只输出指定列的 Markdown 表格，页码必须使用 {{page:outline-节点id}} 占位。' },
+        {
+          role: 'user',
+          content: buildPointToPointPrompt({
+            item,
+            techRequirements,
+            businessScoring,
+            outlineCatalog,
+          }),
+        },
+      ],
+      logTitle: `点对点应答表-${item.title}`,
+    }) || '').trim();
+    if (!content) {
+      throw new Error(`${item.id} ${item.title} 应答表结果为空`);
+    }
+
+    workspaceStore.saveChapterContent({ nodeId: item.id, content });
+    currentOutline = updateOutlineContent(currentOutline, item.id, content);
+    completed += 1;
+    const nextPlan = workspaceStore.loadTechnicalPlan() || {};
+    checkpointTask(
+      {
+        status: 'running',
+        progress: Math.round((completed / leaves.length) * 100),
+        logs: [`已完成 ${item.id} ${item.title}`],
+      },
+      {
+        outlineData: { ...(plan.outlineData || {}), outline: currentOutline },
+        contentGenerationSections: nextPlan.contentGenerationSections,
+      },
+      {
+        outlineData: { ...(plan.outlineData || {}), outline: currentOutline },
+        contentSection: nextPlan.contentGenerationSections?.[item.id],
+      },
+    );
+  }
+
+  updateTask({ logs: ['点对点应答表生成完成。'] });
+  checkpointTask({ status: 'success', progress: 100, error: undefined, logs: ['点对点应答表生成完成。'] });
+}
+
+module.exports = {
+  runPointToPointTask,
+};

--- a/client/electron/services/rejectionCheckStore.cjs
+++ b/client/electron/services/rejectionCheckStore.cjs
@@ -17,10 +17,12 @@ const initialState = {
   activeCheckResultTab: 'rejection',
   invalidBidAndRejectionItems: { status: 'idle', content: '' },
   customCheckItems: '',
-  checkOptions: { rejectionCheck: true, typoCheck: true, logicCheck: true },
+  identityExtraKeywords: '',
+  checkOptions: { rejectionCheck: true, typoCheck: true, logicCheck: true, identityCheck: true },
   rejectionCheckResult: { status: 'idle', findings: [] },
   typoCheckResult: { status: 'idle', findings: [] },
   logicCheckResult: { status: 'idle', findings: [] },
+  identityCheckResult: { status: 'idle', findings: [] },
   extractionTask: undefined,
   checkTask: undefined,
 };
@@ -36,7 +38,10 @@ const resultFieldTypes = {
   rejectionCheckResult: 'rejection',
   typoCheckResult: 'typo',
   logicCheckResult: 'logic',
+  identityCheckResult: 'identity',
 };
+
+const identityCategories = ['person', 'org', 'project', 'contact', 'region', 'english', 'punctuation', 'custom'];
 
 const resultTypeFields = Object.fromEntries(Object.entries(resultFieldTypes).map(([field, type]) => [type, field]));
 
@@ -94,11 +99,11 @@ function normalizeDocumentTab(value) {
 }
 
 function normalizeResultTab(value) {
-  return value === 'custom' ? 'custom' : 'analysis';
+  return value === 'custom' || value === 'identity' ? value : 'analysis';
 }
 
 function normalizeCheckResultTab(value) {
-  return ['rejection', 'typo', 'logic'].includes(value) ? value : 'rejection';
+  return ['rejection', 'typo', 'logic', 'identity'].includes(value) ? value : 'rejection';
 }
 
 function normalizeCheckOptions(options) {
@@ -106,6 +111,7 @@ function normalizeCheckOptions(options) {
     rejectionCheck: true,
     typoCheck: options?.typoCheck !== false,
     logicCheck: options?.logicCheck !== false,
+    identityCheck: options?.identityCheck !== false,
   };
 }
 
@@ -129,6 +135,19 @@ function createDocumentSignature(document) {
     content.slice(0, 800),
     content.slice(-800),
   ].join('\n---yibiao-rejection-signature---\n');
+}
+
+function createIdentityCheckInputSignature(bidDocuments, identityExtraKeywords) {
+  const documents = Array.isArray(bidDocuments) ? bidDocuments : [bidDocuments].filter(Boolean);
+  const bidSignature = documents.map(createDocumentSignature).filter(Boolean).join('\n---yibiao-rejection-bid-document---\n');
+  if (!bidSignature) return '';
+  const extra = String(identityExtraKeywords || '').trim();
+  return [
+    bidSignature,
+    extra.length,
+    extra.slice(0, 800),
+    extra.slice(-800),
+  ].join('\n---yibiao-identity-check-input---\n');
 }
 
 function createRejectionCheckInputSignature(bidDocuments, invalidBidAndRejectionItems, customCheckItems) {
@@ -184,9 +203,9 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
     const timestamp = now();
     db.prepare(`
       INSERT INTO rejection_check_meta (
-        id, step, active_document_tab, active_result_tab, active_check_result_tab, custom_check_items, check_options_json, created_at, updated_at
+        id, step, active_document_tab, active_result_tab, active_check_result_tab, custom_check_items, identity_extra_keywords, check_options_json, created_at, updated_at
       ) VALUES (
-        1, 'documents', 'tender', 'analysis', 'rejection', '', @check_options_json, @timestamp, @timestamp
+        1, 'documents', 'tender', 'analysis', 'rejection', '', '', @check_options_json, @timestamp, @timestamp
       )
     `).run({ check_options_json: JSON.stringify(initialState.checkOptions), timestamp });
     return db.prepare('SELECT * FROM rejection_check_meta WHERE id = 1').get();
@@ -624,6 +643,7 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
     if (resultType === 'rejection') db.prepare('DELETE FROM rejection_check_risk_findings').run();
     if (resultType === 'typo') db.prepare('DELETE FROM rejection_check_typo_findings').run();
     if (resultType === 'logic') db.prepare('DELETE FROM rejection_check_logic_findings').run();
+    if (resultType === 'identity') db.prepare('DELETE FROM rejection_check_identity_findings').run();
   }
 
   function saveFindingRows(resultType, findings) {
@@ -694,6 +714,28 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
         updated_at: timestamp,
       }));
     }
+    if (resultType === 'identity') {
+      const insert = db.prepare(`
+        INSERT INTO rejection_check_identity_findings (
+          finding_id, bid_document_id, category, matched_text, original_excerpt, location_hint, risk_reason, suggestion, sort_order, created_at, updated_at
+        ) VALUES (
+          @finding_id, @bid_document_id, @category, @matched_text, @original_excerpt, @location_hint, @risk_reason, @suggestion, @sort_order, @created_at, @updated_at
+        )
+      `);
+      findings.forEach((item, index) => insert.run({
+        finding_id: String(item.id || `identity-finding-${index + 1}`),
+        bid_document_id: item.bidDocumentId ? String(item.bidDocumentId) : null,
+        category: identityCategories.includes(item.category) ? item.category : 'custom',
+        matched_text: String(item.matchedText || ''),
+        original_excerpt: String(item.originalExcerpt || ''),
+        location_hint: String(item.locationHint || ''),
+        risk_reason: String(item.riskReason || ''),
+        suggestion: String(item.suggestion || ''),
+        sort_order: index,
+        created_at: timestamp,
+        updated_at: timestamp,
+      }));
+    }
   }
 
   function loadResult(resultType) {
@@ -741,6 +783,18 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
         locationHint: item.location_hint || undefined,
       }));
     }
+    if (resultType === 'identity') {
+      return db.prepare('SELECT * FROM rejection_check_identity_findings ORDER BY sort_order ASC').all().map((item) => ({
+        id: item.finding_id,
+        bidDocumentId: item.bid_document_id || fallbackBidDocumentId,
+        category: identityCategories.includes(item.category) ? item.category : 'custom',
+        matchedText: item.matched_text,
+        originalExcerpt: item.original_excerpt,
+        locationHint: item.location_hint,
+        riskReason: item.risk_reason,
+        suggestion: item.suggestion,
+      }));
+    }
     return db.prepare('SELECT * FROM rejection_check_logic_findings ORDER BY sort_order ASC').all().map((item) => ({
       id: item.finding_id,
       bidDocumentId: item.bid_document_id || fallbackBidDocumentId,
@@ -757,6 +811,7 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
     db.prepare('DELETE FROM rejection_check_risk_findings').run();
     db.prepare('DELETE FROM rejection_check_typo_findings').run();
     db.prepare('DELETE FROM rejection_check_logic_findings').run();
+    db.prepare('DELETE FROM rejection_check_identity_findings').run();
     db.prepare("DELETE FROM rejection_check_tasks WHERE type = 'rejection-check-run'").run();
   }
 
@@ -774,6 +829,7 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
     if (hasOwn(partial, 'activeResultTab')) metaUpdates.active_result_tab = normalizeResultTab(partial.activeResultTab);
     if (hasOwn(partial, 'activeCheckResultTab')) metaUpdates.active_check_result_tab = normalizeCheckResultTab(partial.activeCheckResultTab);
     if (hasOwn(partial, 'customCheckItems')) metaUpdates.custom_check_items = String(partial.customCheckItems || '');
+    if (hasOwn(partial, 'identityExtraKeywords')) metaUpdates.identity_extra_keywords = String(partial.identityExtraKeywords || '');
     if (hasOwn(partial, 'checkOptions')) metaUpdates.check_options_json = JSON.stringify(normalizeCheckOptions(partial.checkOptions));
     if (Object.keys(metaUpdates).length) updateMeta(metaUpdates);
 
@@ -815,10 +871,12 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
       activeCheckResultTab: normalizeCheckResultTab(meta.active_check_result_tab),
       invalidBidAndRejectionItems: loadExtraction(),
       customCheckItems: meta.custom_check_items || '',
+      identityExtraKeywords: meta.identity_extra_keywords || '',
       checkOptions: normalizeCheckOptions(safeJsonParse(meta.check_options_json, initialState.checkOptions)),
       rejectionCheckResult: loadResult('rejection'),
       typoCheckResult: loadResult('typo'),
       logicCheckResult: loadResult('logic'),
+      identityCheckResult: loadResult('identity'),
       ...tasks,
     };
   }
@@ -1101,7 +1159,7 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
 
   function saveUiState(partial = {}) {
     const uiState = {};
-    for (const field of ['step', 'activeDocumentTab', 'activeResultTab', 'activeCheckResultTab', 'customCheckItems', 'checkOptions']) {
+    for (const field of ['step', 'activeDocumentTab', 'activeResultTab', 'activeCheckResultTab', 'customCheckItems', 'identityExtraKeywords', 'checkOptions']) {
       if (hasOwn(partial, field)) {
         uiState[field] = partial[field];
       }
@@ -1117,6 +1175,7 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
       db.prepare('DELETE FROM rejection_check_risk_findings').run();
       db.prepare('DELETE FROM rejection_check_typo_findings').run();
       db.prepare('DELETE FROM rejection_check_logic_findings').run();
+      db.prepare('DELETE FROM rejection_check_identity_findings').run();
       db.prepare('DELETE FROM rejection_check_documents').run();
       db.prepare('DELETE FROM rejection_check_meta').run();
       ensureMetaRow();
@@ -1142,6 +1201,7 @@ function createRejectionCheckStore({ app, db, fileService, technicalPlanStore, t
     readDocumentMarkdown,
     createDocumentSignature,
     createRejectionCheckInputSignature,
+    createIdentityCheckInputSignature,
     saveUiState,
   };
 }

--- a/client/electron/services/rejectionCheckTask.cjs
+++ b/client/electron/services/rejectionCheckTask.cjs
@@ -235,6 +235,230 @@ JSON 格式：{"findings":[{"bidDocumentId":"对应投标文件的 bidDocumentId
   ];
 }
 
+const identityCategoryLabels = {
+  person: '人名或简称',
+  org: '单位名称',
+  project: '项目或编号',
+  contact: '联系方式',
+  region: '地区名称',
+  english: '英文或单位',
+  punctuation: '英文标点或符号',
+  custom: '补充词',
+};
+
+const identityCategories = Object.keys(identityCategoryLabels);
+
+function extractProjectIdentifiers(tenderContent) {
+  const text = String(tenderContent || '');
+  const values = new Set();
+  const patterns = [
+    /项目名称[:：]\s*([^\n。；;]{2,80})/g,
+    /工程名称[:：]\s*([^\n。；;]{2,80})/g,
+    /项目编号[:：]\s*([^\n。；;]{2,40})/g,
+    /招标编号[:：]\s*([^\n。；;]{2,40})/g,
+    /标段(?:编号|名称)?[:：]\s*([^\n。；;]{2,40})/g,
+  ];
+  for (const pattern of patterns) {
+    let match = pattern.exec(text);
+    while (match) {
+      const value = normalizeText(match[1]).replace(/[“”"']/g, '');
+      if (value) values.add(value);
+      match = pattern.exec(text);
+    }
+  }
+  return Array.from(values);
+}
+
+function parseIdentityExtraKeywords(value) {
+  return String(value || '')
+    .split(/\r?\n/)
+    .map((item) => item.replace(/^[-*]\s*/, '').trim())
+    .filter(Boolean);
+}
+
+function buildIdentityCheckCommonMessages(input) {
+  const projectIdentifiers = Array.isArray(input.projectIdentifiers) ? input.projectIdentifiers.filter(Boolean) : [];
+  const extraKeywords = parseIdentityExtraKeywords(input.identityExtraKeywords);
+  const messages = [
+    {
+      role: 'user',
+      content: `【暗标检查输入 v1｜内置检查口径】
+请按暗标合规口径检查电子投标文件，查找可能暴露投标人身份或违反暗标格式的内容。
+
+内置检查项：
+1. 人名或简称
+2. 单位 / 企业 / 公司名称
+3. 非本项目的工程名、项目名、项目编号、标段号
+4. 历史项目或业绩举例
+5. 联系方式
+6. 非完整句子的特殊符号
+7. 地区名称
+8. 英文标点、英文字母、英文单位
+9. 用户补充词
+
+排除规则：
+1. 本项目名称、本项目编号、本项目标段号可以合法出现，不要报这些。
+2. 只检查电子投标文件可见正文，不要因为图片或扫描件不可见而猜测。
+3. 命中必须带回原文片段，便于核对。
+
+本项目可合法出现的名称或编号：
+${projectIdentifiers.length ? projectIdentifiers.map((item) => `- ${item}`).join('\n') : '- 未从招标文件提取到明确项目名/编号，请结合招标原文自行判断本项目信息。'}`,
+    },
+  ];
+
+  if (input.tenderContent?.trim()) {
+    messages.push({
+      role: 'user',
+      content: `【暗标检查输入 v1｜招标文件摘录】
+以下招标文件用于识别本项目合法名称、编号和标段，不要把这些内容当成暗标泄漏。
+
+${truncatePromptText(input.tenderContent, 6000)}`,
+    });
+  }
+
+  if (extraKeywords.length) {
+    messages.push({
+      role: 'user',
+      content: `【暗标检查输入 v1｜用户补充词】
+以下词语一行一词。如果投标文件出现这些词，按 custom 类别输出。
+
+${extraKeywords.map((item) => `- ${item}`).join('\n')}`,
+    });
+  }
+
+  messages.push({
+    role: 'user',
+    content: `【暗标检查输入 v1｜投标文件原文】
+以下是本次需要一起检查的多份投标文件 Markdown 原文。每份文件都有唯一 bidDocumentId。后续每条发现必须返回所属 bidDocumentId，并且 matchedText / originalExcerpt 必须能在对应原文中找到。
+
+${formatBidDocumentsForPrompt(input)}`,
+  });
+
+  return messages;
+}
+
+function buildIdentityCheckAnalysisMessages(input) {
+  return [
+    ...buildIdentityCheckCommonMessages(input),
+    {
+      role: 'user',
+      content: `【暗标检查任务 v1｜第一轮：分析】
+请先分析暗标泄漏风险范围，不要输出最终列表。
+
+分析要求：
+1. 先确认本项目名称、编号、标段号，后续不得把这些当成泄漏。
+2. 按内置口径梳理投标文件中最可能暴露身份的位置，例如封面、公司介绍、业绩、联系方式、页眉页脚、签名栏。
+3. 指出需要重点核对的人名、单位名、历史项目、地区、英文和特殊符号。
+4. 仅输出分析结论，使用简体中文。`,
+    },
+  ];
+}
+
+function buildIdentityCheckInspectionMessages(input, analysis) {
+  return [
+    ...buildIdentityCheckCommonMessages(input),
+    { role: 'user', content: `【暗标检查任务 v1｜第一轮分析结果】\n${analysis}` },
+    {
+      role: 'user',
+      content: `【暗标检查任务 v1｜第二轮：定位原文】
+请基于第一轮分析，在投标文件中定位疑似暗标泄漏，并摘录原文。
+
+检查要求：
+1. 每条必须写明 bidDocumentId、命中文本、原文片段和大概位置。
+2. 原文片段必须来自投标文件，不要改写。
+3. 不要把本项目名称、编号、标段号当成泄漏。
+4. 暂不要求 JSON，可用结构化 Markdown 输出初步结果。`,
+    },
+  ];
+}
+
+function buildIdentityCheckFinalMessages(input, analysis, draftFindings) {
+  return [
+    ...buildIdentityCheckCommonMessages(input),
+    { role: 'user', content: `【暗标检查任务 v1｜第一轮分析结果】\n${analysis}` },
+    { role: 'user', content: `【暗标检查任务 v1｜第二轮初步定位结果】\n${draftFindings}` },
+    {
+      role: 'user',
+      content: `【暗标检查任务 v1｜第三轮：JSON 定稿】
+请对第二轮结果去重、补漏并删除无法在原文中核对的条目，最终只输出 JSON。
+
+定稿规则：
+1. 只保留能在投标文件原文中找到 matchedText 的条目。
+2. 删除本项目名称、编号、标段号。
+3. category 只能是 person、org、project、contact、region、english、punctuation、custom。
+4. 如果没有符合条件的发现，返回 {"findings":[]}。
+
+JSON 格式：
+{
+  "findings": [
+    {
+      "bidDocumentId": "对应投标文件的 bidDocumentId",
+      "category": "person",
+      "matchedText": "原文中的命中文本",
+      "originalExcerpt": "包含命中文本的原文短片段",
+      "locationHint": "大概位置、章节或上下文线索",
+      "riskReason": "为什么这属于暗标泄漏或格式风险",
+      "suggestion": "如何改成不暴露身份的写法"
+    }
+  ]
+}
+
+仅输出 JSON，不要输出 Markdown、代码块或解释。`,
+    },
+  ];
+}
+
+function normalizeIdentityCategory(value) {
+  const raw = String(value || '').trim().toLowerCase();
+  if (identityCategories.includes(raw)) return raw;
+  if (raw.includes('人') || raw.includes('person')) return 'person';
+  if (raw.includes('单位') || raw.includes('公司') || raw.includes('企业') || raw.includes('org')) return 'org';
+  if (raw.includes('项目') || raw.includes('编号') || raw.includes('标段') || raw.includes('业绩')) return 'project';
+  if (raw.includes('电话') || raw.includes('邮箱') || raw.includes('联系')) return 'contact';
+  if (raw.includes('地区') || raw.includes('省') || raw.includes('市')) return 'region';
+  if (raw.includes('英文') || raw.includes('字母') || raw.includes('单位')) return 'english';
+  if (raw.includes('标点') || raw.includes('符号')) return 'punctuation';
+  return 'custom';
+}
+
+function normalizeIdentityCheckFindings(parsed, bidDocuments, options = {}) {
+  const documents = Array.isArray(bidDocuments) ? bidDocuments : [];
+  const bidDocumentIds = new Set(documents.map((document) => document.id).filter(Boolean));
+  const documentMap = new Map(documents.map((document) => [document.id, document]));
+  const excluded = new Set((options.projectIdentifiers || []).map((item) => normalizeText(item)).filter(Boolean));
+  const seen = new Set();
+  const findings = [];
+  for (const item of getArrayPayload(parsed, ['findings', 'items', 'risks'])) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const bidDocumentId = getBidDocumentIdFromItem(item, bidDocumentIds);
+    const bidDocument = documentMap.get(bidDocumentId);
+    if (!bidDocument?.content) continue;
+    const matchedText = normalizeText(item.matchedText || item.matched_text || item.text || item.wrongText).slice(0, 80);
+    const originalExcerpt = normalizeText(item.originalExcerpt || item.original_excerpt || item.excerpt || item.originalText);
+    const riskReason = normalizeText(item.riskReason || item.risk_reason || item.reason);
+    if (!matchedText || !riskReason) continue;
+    if (excluded.has(matchedText) || [...excluded].some((value) => value && matchedText.includes(value) && value.length >= 4 && matchedText.length <= value.length + 4)) {
+      continue;
+    }
+    const position = findVerifiedTypoPosition(bidDocument.content, matchedText, originalExcerpt, options);
+    if (position < 0) continue;
+    const key = `${bidDocumentId}\u0000${matchedText}\u0000${position}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    findings.push({
+      id: normalizeText(item.id) || createId('identity_finding'),
+      bidDocumentId,
+      category: normalizeIdentityCategory(item.category),
+      matchedText,
+      originalExcerpt: createVerifiedTypoExcerpt(bidDocument.content, position, matchedText),
+      locationHint: normalizeText(item.locationHint || item.location_hint) || createLineLocationHint(bidDocument.content, position),
+      riskReason,
+      suggestion: normalizeText(item.suggestion) || '请删除或改写为不暴露投标人身份的表述。',
+    });
+  }
+  return findings;
+}
+
 function normalizeRejectionCheckFindings(parsed, bidDocuments) {
   const bidDocumentIds = new Set((Array.isArray(bidDocuments) ? bidDocuments : []).map((document) => document.id).filter(Boolean));
   return getArrayPayload(parsed, ['findings', 'items', 'risks'])
@@ -1494,6 +1718,46 @@ async function runLogicCheck(aiService, input, onProgress) {
   return normalizeLogicCheckFindings(payload, input.bidDocuments);
 }
 
+async function runIdentityCheckForDocuments(aiService, input, onProgress) {
+  onProgress('第一轮：正在分析暗标检查范围。');
+  const analysis = await runText(
+    aiService,
+    { messages: buildIdentityCheckAnalysisMessages(input) },
+    onProgress,
+    '暗标第一轮分析',
+  );
+  onProgress('第二轮：正在定位暗标原文。');
+  const draftFindings = await runText(
+    aiService,
+    { messages: buildIdentityCheckInspectionMessages(input, analysis) },
+    onProgress,
+    '暗标第二轮定位',
+  );
+  onProgress('第三轮：正在补充、去重并生成暗标结果。');
+  const payload = await runJson(aiService, {
+    messages: buildIdentityCheckFinalMessages(input, analysis, draftFindings),
+    schemaName: 'IdentityCheckFindings',
+    progressLabel: '暗标检查结果',
+    failureMessage: '暗标检查结果格式无效，请重新检查',
+  }, onProgress, '暗标第三轮定稿');
+  return normalizeIdentityCheckFindings(payload, input.bidDocuments, {
+    projectIdentifiers: input.projectIdentifiers,
+  });
+}
+
+async function runIdentityCheck(aiService, input, onProgress) {
+  const documents = Array.isArray(input.bidDocuments) ? input.bidDocuments : [];
+  if (shouldUseSegmentedBidDocuments(aiService, documents) && documents.length > 1) {
+    const findings = [];
+    for (const [index, document] of documents.entries()) {
+      onProgress(`正在检查第 ${index + 1}/${documents.length} 份投标文件的暗标风险。`);
+      findings.push(...await runIdentityCheckForDocuments(aiService, { ...input, bidDocuments: [document] }, onProgress));
+    }
+    return findings;
+  }
+  return runIdentityCheckForDocuments(aiService, input, onProgress);
+}
+
 function updateExtractionState(checkpointTask, currentExtraction, taskPartial, extractionPartial) {
   const nextExtraction = { ...(currentExtraction || {}), ...extractionPartial };
   checkpointTask(taskPartial, {
@@ -1609,14 +1873,23 @@ async function runRejectionCheckTask({ aiService, workspaceStore, updateTask, ch
     .filter((document) => document.id && document.content.trim());
   const invalidBidAndRejectionItems = String(state.invalidBidAndRejectionItems?.content || '');
   const customCheckItems = String(state.customCheckItems ?? '');
+  const identityExtraKeywords = String(payload?.identityExtraKeywords ?? state.identityExtraKeywords ?? '');
+  const tenderContent = String(state.tenderDocument?.content || '');
+  const projectIdentifiers = extractProjectIdentifiers(tenderContent);
   const rejectionInputSignature = String(workspaceStore.createRejectionCheckInputSignature(currentBidDocuments, invalidBidAndRejectionItems, customCheckItems) || '');
   const bidSignature = currentBidDocuments.map((document) => workspaceStore.createDocumentSignature(document)).filter(Boolean).join('\n---yibiao-rejection-bid-signature---\n');
+  const identityInputSignature = String(
+    (typeof workspaceStore.createIdentityCheckInputSignature === 'function'
+      ? workspaceStore.createIdentityCheckInputSignature(currentBidDocuments, identityExtraKeywords)
+      : [bidSignature, identityExtraKeywords.trim()].join('\n---yibiao-identity-check-input---\n')) || '',
+  );
   if (!currentBidDocuments.length || !bidSignature) throw new Error('缺少投标文件内容，无法开始检查');
 
   const enabledTasks = [
     runOptions.rejectionCheck ? 'rejection' : '',
     runOptions.typoCheck ? 'typo' : '',
     runOptions.logicCheck ? 'logic' : '',
+    runOptions.identityCheck ? 'identity' : '',
   ].filter(Boolean);
   if (!enabledTasks.length) throw new Error('请至少启用一种检查');
   if (runOptions.rejectionCheck && (!invalidBidAndRejectionItems.trim() || !rejectionInputSignature)) {
@@ -1644,6 +1917,7 @@ async function runRejectionCheckTask({ aiService, workspaceStore, updateTask, ch
   if (runOptions.rejectionCheck) initialPartial.rejectionCheckResult = { ...createRunningResult(rejectionInputSignature, '第一轮：正在分析检查范围。'), findings: [], activeFindingId: undefined };
   if (runOptions.typoCheck) initialPartial.typoCheckResult = { ...createRunningResult(bidSignature, '正在识别错别字候选。'), findings: [], activeFindingId: undefined };
   if (runOptions.logicCheck) initialPartial.logicCheckResult = { ...createRunningResult(bidSignature, '正在检查逻辑谬误。'), findings: [], activeFindingId: undefined };
+  if (runOptions.identityCheck) initialPartial.identityCheckResult = { ...createRunningResult(identityInputSignature, '第一轮：正在分析暗标检查范围。'), findings: [], activeFindingId: undefined };
   updateCheckWorkspace(updateTask, checkpointTask, { status: 'running', progress: 5, logs }, initialPartial, true);
 
   function updateOverall(label, partial, persist = false) {
@@ -1704,6 +1978,14 @@ async function runRejectionCheckTask({ aiService, workspaceStore, updateTask, ch
   }
   if (runOptions.logicCheck) {
     tasks.push(runOne('logic', '逻辑谬误检查', (onProgress) => runLogicCheck(aiService, { bidDocuments: currentBidDocuments }, onProgress), 'logicCheckResult', bidSignature));
+  }
+  if (runOptions.identityCheck) {
+    tasks.push(runOne('identity', '暗标检查', (onProgress) => runIdentityCheck(aiService, {
+      bidDocuments: currentBidDocuments,
+      tenderContent,
+      projectIdentifiers,
+      identityExtraKeywords,
+    }, onProgress), 'identityCheckResult', identityInputSignature));
   }
 
   const results = await Promise.all(tasks);

--- a/client/electron/services/rejectionCheckTask.cjs
+++ b/client/electron/services/rejectionCheckTask.cjs
@@ -1861,7 +1861,7 @@ async function runRejectionCheckTask({ aiService, workspaceStore, updateTask, ch
     ...(payload?.workspaceState || {}),
   };
   const options = state.checkOptions || {};
-  const runOptions = payload?.runOptions || options;
+  let runOptions = payload?.runOptions || options;
   const bidDocuments = Array.isArray(state.bidDocuments) ? state.bidDocuments : [];
   if (typeof workspaceStore.readDocumentMarkdown !== 'function'
     || typeof workspaceStore.createDocumentSignature !== 'function'
@@ -1885,6 +1885,9 @@ async function runRejectionCheckTask({ aiService, workspaceStore, updateTask, ch
   );
   if (!currentBidDocuments.length || !bidSignature) throw new Error('缺少投标文件内容，无法开始检查');
 
+  if (runOptions.rejectionCheck && (!invalidBidAndRejectionItems.trim() || !rejectionInputSignature)) {
+    runOptions = { ...runOptions, rejectionCheck: false };
+  }
   const enabledTasks = [
     runOptions.rejectionCheck ? 'rejection' : '',
     runOptions.typoCheck ? 'typo' : '',
@@ -1892,9 +1895,6 @@ async function runRejectionCheckTask({ aiService, workspaceStore, updateTask, ch
     runOptions.identityCheck ? 'identity' : '',
   ].filter(Boolean);
   if (!enabledTasks.length) throw new Error('请至少启用一种检查');
-  if (runOptions.rejectionCheck && (!invalidBidAndRejectionItems.trim() || !rejectionInputSignature)) {
-    throw new Error('请先完成无效与废标项解析');
-  }
 
   const developerLogger = createRejectionDeveloperLogger(aiService, 'rejection-check-run', {
     bid_signature: bidSignature,

--- a/client/electron/services/rejectionCheckTask.cjs
+++ b/client/electron/services/rejectionCheckTask.cjs
@@ -8,6 +8,7 @@ const typoExcerptRadius = 8;
 const fullPromptLimitRatio = 0.6;
 const rollingSegmentLimitRatio = 0.55;
 const typoSegmentLimitRatio = 0.7;
+const identitySegmentLimitRatio = 0.55;
 const rollingSummaryEvidenceLimit = 60;
 const rollingSummaryResolvedLimit = 40;
 const rollingSummaryConfirmedLimit = 60;
@@ -1075,6 +1076,32 @@ function dedupeLogicFindings(findings) {
   return limitDedupeItems(findings, Number.MAX_SAFE_INTEGER, (item) => `${item.bidDocumentId}\u0000${item.title}\u0000${item.locationHint}\u0000${item.fallacyReason}`);
 }
 
+function dedupeIdentityFindings(findings) {
+  return limitDedupeItems(findings, Number.MAX_SAFE_INTEGER, (item) => `${item.bidDocumentId}\u0000${item.category}\u0000${item.matchedText}\u0000${item.originalExcerpt}`);
+}
+
+function createIdentityCheckUnits(aiService, documents) {
+  const bidDocuments = Array.isArray(documents) ? documents : [];
+  if (!shouldUseSegmentedBidDocuments(aiService, bidDocuments)) {
+    return [{ bidDocuments }];
+  }
+
+  const config = getCurrentAiConfig(aiService);
+  const units = [];
+  for (const document of bidDocuments) {
+    const segments = createBidDocumentSegments(document, config, identitySegmentLimitRatio);
+    for (const segment of segments) {
+      units.push({
+        bidDocuments: [createSegmentPromptDocument(document, segment)],
+        normalizeDocuments: [document],
+        segmentStartOffset: segment.startOffset,
+        segmentEndOffset: segment.endOffset,
+      });
+    }
+  }
+  return units;
+}
+
 function takeRecentItems(items, limit) {
   const source = Array.isArray(items) ? items : [];
   return source.slice(Math.max(0, source.length - limit));
@@ -1718,7 +1745,7 @@ async function runLogicCheck(aiService, input, onProgress) {
   return normalizeLogicCheckFindings(payload, input.bidDocuments);
 }
 
-async function runIdentityCheckForDocuments(aiService, input, onProgress) {
+async function runIdentityCheckForDocuments(aiService, input, onProgress, normalizeOptions = {}) {
   onProgress('第一轮：正在分析暗标检查范围。');
   const analysis = await runText(
     aiService,
@@ -1740,22 +1767,47 @@ async function runIdentityCheckForDocuments(aiService, input, onProgress) {
     progressLabel: '暗标检查结果',
     failureMessage: '暗标检查结果格式无效，请重新检查',
   }, onProgress, '暗标第三轮定稿');
-  return normalizeIdentityCheckFindings(payload, input.bidDocuments, {
+  return normalizeIdentityCheckFindings(payload, normalizeOptions.bidDocuments || input.bidDocuments, {
     projectIdentifiers: input.projectIdentifiers,
+    segmentStartOffset: normalizeOptions.segmentStartOffset,
+    segmentEndOffset: normalizeOptions.segmentEndOffset,
   });
+}
+
+function getIdentityCheckNormalizeOptions(unit) {
+  return {
+    bidDocuments: unit.normalizeDocuments,
+    segmentStartOffset: unit.segmentStartOffset,
+    segmentEndOffset: unit.segmentEndOffset,
+  };
 }
 
 async function runIdentityCheck(aiService, input, onProgress) {
   const documents = Array.isArray(input.bidDocuments) ? input.bidDocuments : [];
-  if (shouldUseSegmentedBidDocuments(aiService, documents) && documents.length > 1) {
-    const findings = [];
-    for (const [index, document] of documents.entries()) {
-      onProgress(`正在检查第 ${index + 1}/${documents.length} 份投标文件的暗标风险。`);
-      findings.push(...await runIdentityCheckForDocuments(aiService, { ...input, bidDocuments: [document] }, onProgress));
-    }
-    return findings;
+  const units = createIdentityCheckUnits(aiService, documents);
+  if (units.length <= 1) {
+    const unit = units[0] || { bidDocuments: documents };
+    return runIdentityCheckForDocuments(
+      aiService,
+      { ...input, bidDocuments: unit.bidDocuments },
+      onProgress,
+      getIdentityCheckNormalizeOptions(unit),
+    );
   }
-  return runIdentityCheckForDocuments(aiService, input, onProgress);
+
+  const findings = [];
+  onProgress('正在按上下文长度分段检查暗标风险。');
+  for (const [index, unit] of units.entries()) {
+    onProgress(`正在检查暗标风险第 ${index + 1}/${units.length} 段。`);
+    findings.push(...await runIdentityCheckForDocuments(
+      aiService,
+      { ...input, bidDocuments: unit.bidDocuments },
+      onProgress,
+      getIdentityCheckNormalizeOptions(unit),
+    ));
+  }
+  onProgress('正在合并暗标检查结果。');
+  return dedupeIdentityFindings(findings);
 }
 
 function updateExtractionState(checkpointTask, currentExtraction, taskPartial, extractionPartial) {
@@ -2007,4 +2059,9 @@ async function runRejectionCheckTask({ aiService, workspaceStore, updateTask, ch
 module.exports = {
   runRejectionItemsExtractionTask,
   runRejectionCheckTask,
+  _internals: {
+    createIdentityCheckUnits,
+    dedupeIdentityFindings,
+    shouldUseSegmentedBidDocuments,
+  },
 };

--- a/client/electron/services/rejectionCheckTask.test.cjs
+++ b/client/electron/services/rejectionCheckTask.test.cjs
@@ -1,0 +1,50 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { _internals } = require('./rejectionCheckTask.cjs');
+
+function createAiService(contextLengthLimit) {
+  return {
+    getConfig() {
+      return { context_length_limit: contextLengthLimit };
+    },
+  };
+}
+
+function createDocument(id, content) {
+  return { id, fileName: `${id}.md`, content };
+}
+
+describe('createIdentityCheckUnits', () => {
+  it('keeps a small package as one unsegmented unit', () => {
+    const documents = [
+      createDocument('doc-a', '甲方名称'),
+      createDocument('doc-b', '乙方名称'),
+    ];
+    const units = _internals.createIdentityCheckUnits(createAiService(400000), documents);
+    assert.equal(units.length, 1);
+    assert.deepEqual(units[0].bidDocuments, documents);
+    assert.equal(units[0].normalizeDocuments, undefined);
+  });
+
+  it('splits a single oversized document into content segments', () => {
+    const document = createDocument('doc-huge', `${'暗标检查。'.repeat(80)}\n`.repeat(6));
+    const units = _internals.createIdentityCheckUnits(createAiService(200), [document]);
+    assert.ok(units.length > 1);
+    assert.ok(units.every((unit) => unit.bidDocuments.length === 1));
+    assert.ok(units.every((unit) => unit.bidDocuments[0].content.length < document.content.length));
+    assert.ok(units.every((unit) => unit.normalizeDocuments[0] === document));
+    assert.ok(units.every((unit) => Number.isFinite(unit.segmentStartOffset)));
+    const reconstructed = units.map((unit) => unit.bidDocuments[0].content).join('');
+    assert.equal(reconstructed, document.content);
+  });
+
+  it('splits each oversized document instead of sending the file whole', () => {
+    const first = createDocument('doc-1', `${'单位名称。'.repeat(80)}\n`.repeat(4));
+    const second = createDocument('doc-2', `${'联系电话。'.repeat(80)}\n`.repeat(4));
+    const units = _internals.createIdentityCheckUnits(createAiService(200), [first, second]);
+    assert.ok(units.length > 2);
+    assert.ok(units.some((unit) => unit.normalizeDocuments[0].id === 'doc-1'));
+    assert.ok(units.some((unit) => unit.normalizeDocuments[0].id === 'doc-2'));
+    assert.ok(units.every((unit) => unit.bidDocuments[0].content.length < Math.max(first.content.length, second.content.length)));
+  });
+});

--- a/client/electron/services/sqliteDatabase.cjs
+++ b/client/electron/services/sqliteDatabase.cjs
@@ -3,7 +3,9 @@ const path = require('node:path');
 const Database = require('better-sqlite3');
 const { getWorkspaceDatabasePath } = require('../utils/paths.cjs');
 
-const schemaVersion = 24;
+const { createKnowledgeSearchSchema, backfillKnowledgeSearch } = require('./knowledgeSearchIndex.cjs');
+
+const schemaVersion = 25;
 
 function createInitialSchema(db) {
   db.exec(`
@@ -1131,6 +1133,14 @@ const schemaHealthTableGroups = [
     repair: createRejectionCheckIdentitySchema,
   },
   {
+    version: 25,
+    tables: [
+      'knowledge_search_rows',
+      'knowledge_search_fts',
+    ],
+    repair: createKnowledgeSearchSchema,
+  },
+  {
     version: 3,
     tables: [
       'knowledge_folders',
@@ -1526,7 +1536,17 @@ const migrations = [
     description: '新增废标项检查暗标检查结果表',
     up: createRejectionCheckIdentitySchema,
   },
+  {
+    version: 25,
+    description: '新增知识库全局检索 FTS 索引',
+    up: migrateKnowledgeSearchSchema,
+  },
 ];
+
+function migrateKnowledgeSearchSchema(db) {
+  createKnowledgeSearchSchema(db);
+  backfillKnowledgeSearch(db, { force: true });
+}
 
 function timestampForFileName() {
   return new Date().toISOString().replace(/[-:]/g, '').replace(/T/, '-').replace(/\..*$/, '');

--- a/client/electron/services/sqliteDatabase.cjs
+++ b/client/electron/services/sqliteDatabase.cjs
@@ -3,7 +3,7 @@ const path = require('node:path');
 const Database = require('better-sqlite3');
 const { getWorkspaceDatabasePath } = require('../utils/paths.cjs');
 
-const schemaVersion = 23;
+const schemaVersion = 24;
 
 function createInitialSchema(db) {
   db.exec(`
@@ -593,6 +593,7 @@ function createRejectionCheckSchema(db) {
       active_result_tab TEXT NOT NULL DEFAULT 'analysis',
       active_check_result_tab TEXT NOT NULL DEFAULT 'rejection',
       custom_check_items TEXT NOT NULL DEFAULT '',
+      identity_extra_keywords TEXT NOT NULL DEFAULT '',
       check_options_json TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
@@ -699,6 +700,45 @@ function createRejectionCheckSchema(db) {
 
     CREATE INDEX IF NOT EXISTS idx_rejection_check_logic_order
     ON rejection_check_logic_findings(sort_order);
+
+    CREATE TABLE IF NOT EXISTS rejection_check_identity_findings (
+      finding_id TEXT PRIMARY KEY,
+      bid_document_id TEXT,
+      category TEXT NOT NULL,
+      matched_text TEXT NOT NULL,
+      original_excerpt TEXT NOT NULL,
+      location_hint TEXT NOT NULL,
+      risk_reason TEXT NOT NULL,
+      suggestion TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_rejection_check_identity_order
+    ON rejection_check_identity_findings(sort_order);
+  `);
+}
+
+function createRejectionCheckIdentitySchema(db) {
+  addColumnIfMissing(db, 'rejection_check_meta', 'identity_extra_keywords', "TEXT NOT NULL DEFAULT ''");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS rejection_check_identity_findings (
+      finding_id TEXT PRIMARY KEY,
+      bid_document_id TEXT,
+      category TEXT NOT NULL,
+      matched_text TEXT NOT NULL,
+      original_excerpt TEXT NOT NULL,
+      location_hint TEXT NOT NULL,
+      risk_reason TEXT NOT NULL,
+      suggestion TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_rejection_check_identity_order
+    ON rejection_check_identity_findings(sort_order);
   `);
 }
 
@@ -1084,6 +1124,13 @@ const schemaHealthTableGroups = [
     repair: createRejectionCheckSchema,
   },
   {
+    version: 24,
+    tables: [
+      'rejection_check_identity_findings',
+    ],
+    repair: createRejectionCheckIdentitySchema,
+  },
+  {
     version: 3,
     tables: [
       'knowledge_folders',
@@ -1227,6 +1274,20 @@ const schemaHealthColumnGroups = [
   {
     version: 12,
     table: 'rejection_check_logic_findings',
+    columns: {
+      bid_document_id: 'TEXT',
+    },
+  },
+  {
+    version: 24,
+    table: 'rejection_check_meta',
+    columns: {
+      identity_extra_keywords: "TEXT NOT NULL DEFAULT ''",
+    },
+  },
+  {
+    version: 24,
+    table: 'rejection_check_identity_findings',
     columns: {
       bid_document_id: 'TEXT',
     },
@@ -1459,6 +1520,11 @@ const migrations = [
     version: 23,
     description: '新增可行性研究报告工作区表结构',
     up: createFeasibilityReportSchema,
+  },
+  {
+    version: 24,
+    description: '新增废标项检查暗标检查结果表',
+    up: createRejectionCheckIdentitySchema,
   },
 ];
 

--- a/client/electron/services/taskService.cjs
+++ b/client/electron/services/taskService.cjs
@@ -2,6 +2,8 @@ const crypto = require('node:crypto');
 const { runBidSectionExtractionTask } = require('./bidSectionExtractionTask.cjs');
 const { runBidAnalysisTask } = require('./bidAnalysisTask.cjs');
 const { runContentGenerationTask } = require('./contentGenerationTask.cjs');
+const { runTemplateFillTask } = require('./templateFillTask.cjs');
+const { runPointToPointTask } = require('./pointToPointTask.cjs');
 const { runGlobalFactsTaskV2 } = require('./globalFactsTaskV2.cjs');
 const { runOutlineGenerationTaskV2 } = require('./outlineGenerationTaskV2.cjs');
 const { runOutlineAdjustmentTask } = require('./outlineAdjustmentTask.cjs');
@@ -85,6 +87,24 @@ const taskDefinitions = {
     lockPolicy: 'group-exclusive',
     stateKey: 'technicalPlan',
     field: 'contentGenerationTask',
+  },
+  'template-fill-generation': {
+    label: '模板填写',
+    group: 'technical-plan',
+    groupLabel: '技术方案',
+    step: 5,
+    lockPolicy: 'group-exclusive',
+    stateKey: 'technicalPlan',
+    field: 'templateFillTask',
+  },
+  'point-to-point-generation': {
+    label: '点对点应答表',
+    group: 'technical-plan',
+    groupLabel: '技术方案',
+    step: 5,
+    lockPolicy: 'group-exclusive',
+    stateKey: 'technicalPlan',
+    field: 'pointToPointTask',
   },
   'rejection-items-extraction': {
     label: '无效与废标项解析',
@@ -445,6 +465,10 @@ function createTaskService({ aiService, agentService, autoConfirmationService, t
       }
     }
 
+    if (task.type === 'template-fill-generation' || task.type === 'point-to-point-generation') {
+      copyPatchFields(patch, state, ['outlineData', 'contentGenerationSections']);
+    }
+
     if (hasOwn(eventPatch, 'outlineData')) {
       patch.outlineData = eventPatch.outlineData;
     }
@@ -586,6 +610,14 @@ function createTaskService({ aiService, agentService, autoConfirmationService, t
             return;
           }
           throw new Error('正文生成已暂停，请先继续当前正文生成任务或重置技术方案后再启动新的任务。');
+        }
+        const pausedTemplateTask = technicalPlan.templateFillTask;
+        if (pausedTemplateTask?.status === 'paused' && type !== 'template-fill-generation') {
+          throw new Error('模板填写已暂停，请先完成或重置后再启动新的任务。');
+        }
+        const pausedPointToPointTask = technicalPlan.pointToPointTask;
+        if (pausedPointToPointTask?.status === 'paused' && type !== 'point-to-point-generation') {
+          throw new Error('点对点应答表已暂停，请先完成或重置后再启动新的任务。');
         }
       }
       if (definition.group === 'feasibility-report' && feasibilityReportStore) {
@@ -1104,6 +1136,29 @@ function createTaskService({ aiService, agentService, autoConfirmationService, t
     emit(recoveredTask, buildSnapshot(getTaskDefinition('global-facts-adjustment'), partial, recoveredTask));
   }
 
+  function recoverInterruptedChapterModeTask(technicalPlan, type, field, message) {
+    if (activeTasks.has(type)) {
+      return;
+    }
+    const task = technicalPlan[field];
+    if (!isActiveTaskStatus(task?.status)) {
+      return;
+    }
+    const logs = Array.isArray(task.logs) ? task.logs : [];
+    const recoveredTask = {
+      ...task,
+      status: 'error',
+      progress: 100,
+      pause_requested: false,
+      error: message,
+      logs: logs.includes(message) ? logs : [...logs, message],
+      updated_at: now(),
+    };
+    const partial = { [field]: recoveredTask };
+    technicalPlanStore.updateTechnicalPlanWithoutReload(partial);
+    emit(recoveredTask, buildSnapshot(getTaskDefinition(type), partial, recoveredTask));
+  }
+
   function recoverInterruptedBidAnalysisTask(technicalPlan) {
     if (activeTasks.has('bid-analysis')) {
       return;
@@ -1327,6 +1382,8 @@ function createTaskService({ aiService, agentService, autoConfirmationService, t
   recoverInterruptedOutlineGenerationTask(technicalPlanRecoveryState);
   recoverInterruptedOutlineAdjustmentTask(technicalPlanRecoveryState);
   recoverInterruptedContentGenerationTask(technicalPlanRecoveryState);
+  recoverInterruptedChapterModeTask(technicalPlanRecoveryState, 'template-fill-generation', 'templateFillTask', '上次模板填写未完成，请重新填充。');
+  recoverInterruptedChapterModeTask(technicalPlanRecoveryState, 'point-to-point-generation', 'pointToPointTask', '上次点对点应答表未完成，请重新生成。');
   recoverInterruptedGlobalFactsTask(technicalPlanRecoveryState);
   recoverInterruptedGlobalFactsAdjustmentTask(technicalPlanRecoveryState);
   recoverInterruptedRejectionCheckTasks(rejectionCheckRecoveryState);
@@ -1415,6 +1472,12 @@ function createTaskService({ aiService, agentService, autoConfirmationService, t
         throw new Error('当前目录没有字数控制生效快照，请重新生成目录');
       }
       return startManagedTask('content-generation', payload, runContentGenerationTask);
+    },
+    startTemplateFill(payload) {
+      return startManagedTask('template-fill-generation', payload, runTemplateFillTask);
+    },
+    startPointToPoint(payload) {
+      return startManagedTask('point-to-point-generation', payload, runPointToPointTask);
     },
     pauseContentGeneration() {
       const task = activeTasks.get('content-generation');

--- a/client/electron/services/technicalPlanStore.cjs
+++ b/client/electron/services/technicalPlanStore.cjs
@@ -1,7 +1,7 @@
 const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
-const { getBidAnalysisTasks } = require('./bidAnalysisTask.cjs');
+const { getBidAnalysisTaskById, getBidAnalysisTasks } = require('./bidAnalysisTask.cjs');
 const {
   getTechnicalPlanGeneratedIllustrationsDir,
   getTechnicalPlanIllustrationsDir,
@@ -72,6 +72,8 @@ const taskFieldTypes = {
   globalFactsTask: 'global-facts-generation',
   globalFactsAdjustmentTask: 'global-facts-adjustment',
   contentGenerationTask: 'content-generation',
+  templateFillTask: 'template-fill-generation',
+  pointToPointTask: 'point-to-point-generation',
 };
 
 const taskTypeFields = Object.fromEntries(Object.entries(taskFieldTypes).map(([field, type]) => [type, field]));
@@ -81,6 +83,8 @@ const originalPlanDownstreamTaskTypes = Object.freeze([
   'global-facts-generation',
   'global-facts-adjustment',
   'content-generation',
+  'template-fill-generation',
+  'point-to-point-generation',
 ]);
 
 function appendImportFailureParts(messageParts, errors) {
@@ -933,7 +937,7 @@ function createTechnicalPlanStore({ app, db, fileService, agentService, taskLogS
   }
 
   function getBidItemLabel(itemId, fallbackLabel) {
-    const task = getBidAnalysisTasks('full').find((item) => item.id === itemId) || getBidAnalysisTasks('key').find((item) => item.id === itemId);
+    const task = getBidAnalysisTaskById(itemId);
     return fallbackLabel || task?.label || itemId;
   }
 
@@ -1561,7 +1565,7 @@ function createTechnicalPlanStore({ app, db, fileService, agentService, taskLogS
     db.prepare("UPDATE technical_plan_outline_nodes SET content = '', updated_at = ?").run(now());
     db.prepare('DELETE FROM technical_plan_content_sections').run();
     db.prepare('DELETE FROM technical_plan_content_plans').run();
-    db.prepare("DELETE FROM technical_plan_tasks WHERE type = 'content-generation'").run();
+    db.prepare("DELETE FROM technical_plan_tasks WHERE type IN ('content-generation', 'template-fill-generation', 'point-to-point-generation')").run();
     clearContentIllustrationPlan();
     clearTechnicalPlanMermaidCache();
     updateMeta({ content_generation_runtime_json: null });
@@ -1647,9 +1651,9 @@ function createTechnicalPlanStore({ app, db, fileService, agentService, taskLogS
   }
 
   function assertOutlineMutationAllowed() {
-    const task = db.prepare("SELECT status FROM technical_plan_tasks WHERE type = 'content-generation'").get();
-    if (['running', 'pausing', 'paused'].includes(task?.status)) {
-      throw new Error('正文生成任务正在运行或暂停中，请结束后再调整目录');
+    const task = db.prepare("SELECT status FROM technical_plan_tasks WHERE type IN ('content-generation', 'template-fill-generation', 'point-to-point-generation') AND status IN ('running', 'pausing', 'paused') LIMIT 1").get();
+    if (task) {
+      throw new Error('正文或模板任务正在运行或暂停中，请结束后再调整目录');
     }
   }
 
@@ -2098,7 +2102,7 @@ function createTechnicalPlanStore({ app, db, fileService, agentService, taskLogS
       const nextIds = new Set(rows.map((row) => row.node_id));
       restoreMappedContentRows({ snapshot, idMap, affectedIds, nextIds, clearAll });
       if (invalidatesContentTask) {
-        db.prepare("DELETE FROM technical_plan_tasks WHERE type = 'content-generation'").run();
+        db.prepare("DELETE FROM technical_plan_tasks WHERE type IN ('content-generation', 'template-fill-generation', 'point-to-point-generation')").run();
         clearTechnicalPlanMermaidCache();
         updateMeta({ content_generation_runtime_json: null });
       }
@@ -2119,6 +2123,8 @@ function createTechnicalPlanStore({ app, db, fileService, agentService, taskLogS
       ...(invalidatesContentTask ? {
         contentGenerationTask: undefined,
         contentGenerationRuntime: undefined,
+        templateFillTask: undefined,
+        pointToPointTask: undefined,
       } : {}),
     };
   }

--- a/client/electron/services/technicalPlanStore.cjs
+++ b/client/electron/services/technicalPlanStore.cjs
@@ -2097,6 +2097,15 @@ function createTechnicalPlanStore({ app, db, fileService, agentService, taskLogS
       saveOutlineData(outlineToSave);
       if (!outlineToSave?.outline?.length) {
         updateMeta({ outline_word_control_snapshot_json: null });
+      } else if (reason === 'replace') {
+        const meta = readMetaRow();
+        const shouldPersistWordControlSnapshot = Boolean(request.persistWordControlSnapshot) || !meta.outline_word_control_snapshot_json;
+        if (shouldPersistWordControlSnapshot) {
+          const wordControlSnapshot = normalizeOutlineWordControlOptions(
+            safeJsonParse(meta.outline_word_control_options_json, defaultOutlineWordControlOptions),
+          );
+          updateMeta({ outline_word_control_snapshot_json: JSON.stringify(wordControlSnapshot) });
+        }
       }
       const rows = flattenOutlineItems(outlineToSave?.outline || []);
       const nextIds = new Set(rows.map((row) => row.node_id));
@@ -2113,8 +2122,14 @@ function createTechnicalPlanStore({ app, db, fileService, agentService, taskLogS
       ? safeJsonParse(readMetaRow().content_generation_runtime_json, undefined)
       : undefined;
     const sortedContentTask = reason === 'sort' ? loadTask('content-generation') : undefined;
+    const savedMeta = readMetaRow();
     return {
       outlineData: savedOutlineData,
+      ...(reason === 'replace' ? {
+        outlineWordControlSnapshot: savedMeta.outline_word_control_snapshot_json
+          ? normalizeOutlineWordControlOptions(safeJsonParse(savedMeta.outline_word_control_snapshot_json, defaultOutlineWordControlOptions))
+          : undefined,
+      } : {}),
       contentIllustrationPlan: reason === 'sort' ? savedIllustrationPlan : undefined,
       ...(reason === 'sort' ? {
         contentGenerationTask: sortedContentTask,

--- a/client/electron/services/templateFillTask.cjs
+++ b/client/electron/services/templateFillTask.cjs
@@ -31,7 +31,7 @@ function loadSelectedKnowledgeText(knowledgeBaseService, documentIds, item) {
   const selectedIds = new Set((Array.isArray(item?.knowledge_item_ids) ? item.knowledge_item_ids : [])
     .map((id) => String(id || '').trim())
     .filter(Boolean));
-  if (!knowledgeBaseService?.readReferences || !Array.isArray(documentIds) || !documentIds.length) {
+  if (!selectedIds.size || !knowledgeBaseService?.readReferences || !Array.isArray(documentIds) || !documentIds.length) {
     return '';
   }
   try {
@@ -42,7 +42,7 @@ function loadSelectedKnowledgeText(knowledgeBaseService, documentIds, item) {
         const itemId = String(knowledgeItem?.id || '').trim();
         const content = String(knowledgeItem?.content || '').trim();
         if (!content) continue;
-        if (!selectedIds.size || selectedIds.has(itemId) || selectedIds.has(`${reference?.document?.id}::${itemId}`)) {
+        if (selectedIds.has(itemId) || selectedIds.has(`${reference?.document?.id}::${itemId}`)) {
           parts.push(content);
         }
       }
@@ -174,5 +174,6 @@ async function runTemplateFillTask({
 }
 
 module.exports = {
+  loadSelectedKnowledgeText,
   runTemplateFillTask,
 };

--- a/client/electron/services/templateFillTask.cjs
+++ b/client/electron/services/templateFillTask.cjs
@@ -1,0 +1,178 @@
+function singleLine(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function collectLeaves(items, mode) {
+  const leaves = [];
+  for (const item of Array.isArray(items) ? items : []) {
+    if (item?.children?.length) {
+      leaves.push(...collectLeaves(item.children, mode));
+      continue;
+    }
+    if (!mode || item?.content_mode === mode) {
+      leaves.push(item);
+    }
+  }
+  return leaves;
+}
+
+function formatGlobalFacts(globalFacts) {
+  return (Array.isArray(globalFacts) ? globalFacts : [])
+    .map((group, index) => {
+      const title = singleLine(group?.title || `全局事实${index + 1}`);
+      const content = String(group?.content || '').trim();
+      return title && content ? `## ${title}\n${content}` : '';
+    })
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+function loadSelectedKnowledgeText(knowledgeBaseService, documentIds, item) {
+  const selectedIds = new Set((Array.isArray(item?.knowledge_item_ids) ? item.knowledge_item_ids : [])
+    .map((id) => String(id || '').trim())
+    .filter(Boolean));
+  if (!knowledgeBaseService?.readReferences || !Array.isArray(documentIds) || !documentIds.length) {
+    return '';
+  }
+  try {
+    const references = knowledgeBaseService.readReferences(documentIds);
+    const parts = [];
+    for (const reference of Array.isArray(references) ? references : []) {
+      for (const knowledgeItem of Array.isArray(reference?.items) ? reference.items : []) {
+        const itemId = String(knowledgeItem?.id || '').trim();
+        const content = String(knowledgeItem?.content || '').trim();
+        if (!content) continue;
+        if (!selectedIds.size || selectedIds.has(itemId) || selectedIds.has(`${reference?.document?.id}::${itemId}`)) {
+          parts.push(content);
+        }
+      }
+    }
+    return parts.join('\n\n');
+  } catch {
+    return '';
+  }
+}
+
+function updateOutlineContent(items, nodeId, content) {
+  return (items || []).map((item) => {
+    if (item.id === nodeId) {
+      return { ...item, content };
+    }
+    return item.children?.length
+      ? { ...item, children: updateOutlineContent(item.children, nodeId, content) }
+      : item;
+  });
+}
+
+function buildTemplateFillPrompt({ item, tenderMarkdown, responseFileRequirements, globalFactsText, knowledgeText }) {
+  return `任务：根据招标原文填写“${singleLine(item.title)}”对应的模板或表格。
+
+章节说明：
+${String(item.description || '').trim() || '无'}
+
+工作要求：
+1. 先从招标文件和响应文件要求中抽出该小节对应的原文模板、表格字段或填写口径，再填写。
+2. 只填写有依据的内容；没有依据的格子写“【待填写】”，不要编造资质、业绩、报价、联系人或证书编号。
+3. 优先输出 Markdown 表格；如果原文是固定格式，尽量保持原字段顺序。
+4. 不要输出分析过程，只输出可直接写入正文的 Markdown。
+
+响应文件要求：
+${String(responseFileRequirements || '').trim() || '未提供'}
+
+全局事实：
+${globalFactsText || '未提供'}
+
+已选知识库：
+${knowledgeText || '未选择'}
+
+招标文件：
+${String(tenderMarkdown || '').trim() || '未提供'}`;
+}
+
+async function runTemplateFillTask({
+  aiService,
+  workspaceStore,
+  knowledgeBaseService,
+  updateTask,
+  checkpointTask,
+  payload,
+}) {
+  const plan = workspaceStore.loadTechnicalPlan() || {};
+  const outline = plan.outlineData?.outline || [];
+  const requestedIds = new Set((Array.isArray(payload?.nodeIds) ? payload.nodeIds : [])
+    .map((id) => String(id || '').trim())
+    .filter(Boolean));
+  const leaves = collectLeaves(outline, 'template-fill')
+    .filter((item) => !requestedIds.size || requestedIds.has(item.id));
+  if (!leaves.length) {
+    throw new Error('当前目录没有需要填充的模板小节');
+  }
+
+  const tenderMarkdown = workspaceStore.readTenderMarkdown();
+  const responseFileRequirements = plan.bidAnalysisTasks?.responseFileRequirements?.status === 'success'
+    ? plan.bidAnalysisTasks.responseFileRequirements.content
+    : '';
+  const globalFactsText = formatGlobalFacts(plan.globalFacts);
+  const knowledgeDocumentIds = plan.referenceKnowledgeDocumentIds || [];
+
+  let currentOutline = outline;
+  let completed = 0;
+  checkpointTask({
+    status: 'running',
+    progress: 0,
+    logs: [`开始填充 ${leaves.length} 个模板小节。`],
+  });
+
+  for (const item of leaves) {
+    checkpointTask({
+      status: 'running',
+      progress: Math.round((completed / leaves.length) * 100),
+      logs: [`正在填充 ${item.id} ${item.title}`],
+    });
+    const content = String(await aiService.chat({
+      messages: [
+        { role: 'system', content: '你是投标文件模板填写助手。只根据给定材料填写，不确定就写【待填写】。' },
+        {
+          role: 'user',
+          content: buildTemplateFillPrompt({
+            item,
+            tenderMarkdown,
+            responseFileRequirements,
+            globalFactsText,
+            knowledgeText: loadSelectedKnowledgeText(knowledgeBaseService, knowledgeDocumentIds, item),
+          }),
+        },
+      ],
+      logTitle: `模板填写-${item.title}`,
+    }) || '').trim();
+    if (!content) {
+      throw new Error(`${item.id} ${item.title} 填充结果为空`);
+    }
+
+    workspaceStore.saveChapterContent({ nodeId: item.id, content });
+    currentOutline = updateOutlineContent(currentOutline, item.id, content);
+    completed += 1;
+    const nextPlan = workspaceStore.loadTechnicalPlan() || {};
+    checkpointTask(
+      {
+        status: 'running',
+        progress: Math.round((completed / leaves.length) * 100),
+        logs: [`已完成 ${item.id} ${item.title}`],
+      },
+      {
+        outlineData: { ...(plan.outlineData || {}), outline: currentOutline },
+        contentGenerationSections: nextPlan.contentGenerationSections,
+      },
+      {
+        outlineData: { ...(plan.outlineData || {}), outline: currentOutline },
+        contentSection: nextPlan.contentGenerationSections?.[item.id],
+      },
+    );
+  }
+
+  checkpointTask({ status: 'success', progress: 100, error: undefined, logs: ['模板填写完成。'] });
+}
+
+module.exports = {
+  runTemplateFillTask,
+};

--- a/client/electron/services/templateFillTask.test.cjs
+++ b/client/electron/services/templateFillTask.test.cjs
@@ -1,0 +1,35 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { loadSelectedKnowledgeText } = require('./templateFillTask.cjs');
+
+function createKnowledgeBaseService() {
+  return {
+    readReferences() {
+      return [
+        {
+          document: { id: 'doc-1' },
+          items: [
+            { id: 'item-a', content: '条目甲正文' },
+            { id: 'item-b', content: '条目乙正文' },
+          ],
+        },
+      ];
+    },
+  };
+}
+
+describe('templateFillTask.loadSelectedKnowledgeText', () => {
+  it('does not inject reference documents when the leaf has no knowledge items', () => {
+    const text = loadSelectedKnowledgeText(createKnowledgeBaseService(), ['doc-1'], {
+      knowledge_item_ids: [],
+    });
+    assert.equal(text, '');
+  });
+
+  it('only injects the checked knowledge items', () => {
+    const text = loadSelectedKnowledgeText(createKnowledgeBaseService(), ['doc-1'], {
+      knowledge_item_ids: ['doc-1::item-b'],
+    });
+    assert.equal(text, '条目乙正文');
+  });
+});

--- a/client/electron/utils/textNormalization.cjs
+++ b/client/electron/utils/textNormalization.cjs
@@ -1,0 +1,66 @@
+function convertChineseQuotes(value) {
+  let result = '';
+  let doubleOpen = true;
+  let singleOpen = true;
+  const text = String(value || '');
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === '"') {
+      result += doubleOpen ? '“' : '”';
+      doubleOpen = !doubleOpen;
+      continue;
+    }
+    if (char === "'") {
+      const prev = text[index - 1] || '';
+      const next = text[index + 1] || '';
+      if (/[A-Za-z]/.test(prev) && /[A-Za-z]/.test(next)) {
+        result += char;
+        continue;
+      }
+      result += singleOpen ? '‘' : '’';
+      singleOpen = !singleOpen;
+      continue;
+    }
+    result += char;
+  }
+  return result;
+}
+
+function stripChineseSpaces(value) {
+  return String(value || '').replace(/([\u3400-\u9FFF\uF900-\uFAFF])[ \t]+(?=[\u3400-\u9FFF\uF900-\uFAFF])/g, '$1');
+}
+
+function applyTextNormalization(value, options) {
+  if (!options?.chinese_quotes && !options?.strip_spaces) return String(value || '');
+  let text = String(value || '');
+  if (options.chinese_quotes) text = convertChineseQuotes(text);
+  if (options.strip_spaces) text = stripChineseSpaces(text);
+  return text;
+}
+
+function protectMarkdownMarkup(markdown, stash) {
+  return String(markdown || '')
+    .replace(/```[\s\S]*?```/g, stash)
+    .replace(/`[^`\n]+`/g, stash)
+    .replace(/<\/?[A-Za-z](?:[^>"']|"[^"]*"|'[^']*')*>/g, stash)
+    .replace(/<https?:[^>\s]+>/gi, stash)
+    .replace(/\]\((?:<[^>\n]+>|[^)\s]+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\)/g, stash)
+    .replace(/^\s*\[[^\]]+\]:\s+(?:<[^>\n]+>|\S+)(?:\s+(?:"[^"]*"|'[^']*'|\([^)]*\)))?\s*$/gm, stash);
+}
+
+function applyTextNormalizationToMarkdown(markdown, options) {
+  if (!options?.chinese_quotes && !options?.strip_spaces) return String(markdown || '');
+  const preserved = [];
+  const protectedText = protectMarkdownMarkup(markdown, (block) => {
+    preserved.push(block);
+    return `\0FENCE${preserved.length - 1}\0`;
+  });
+  return applyTextNormalization(protectedText, options).replace(/\0FENCE(\d+)\0/g, (_, index) => preserved[Number(index)] || '');
+}
+
+module.exports = {
+  applyTextNormalization,
+  applyTextNormalizationToMarkdown,
+  convertChineseQuotes,
+  stripChineseSpaces,
+};

--- a/client/electron/utils/textNormalization.test.cjs
+++ b/client/electron/utils/textNormalization.test.cjs
@@ -1,0 +1,38 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { applyTextNormalizationToMarkdown, convertChineseQuotes } = require('./textNormalization.cjs');
+
+const quotesOn = { chinese_quotes: true };
+
+describe('applyTextNormalizationToMarkdown', () => {
+  it('converts quotes in ordinary Markdown text', () => {
+    assert.equal(applyTextNormalizationToMarkdown('他说"你好"', quotesOn), '他说“你好”');
+  });
+
+  it('keeps link destination and title quotes intact', () => {
+    const source = '详见[链接](https://example.com "标题")。';
+    assert.equal(applyTextNormalizationToMarkdown(source, quotesOn), '详见[链接](https://example.com "标题")。');
+  });
+
+  it('keeps HTML attribute quotes intact and still converts nearby text', () => {
+    const source = '见图<img src="diagram.png" alt="示意图">中的"要点"。';
+    assert.equal(
+      applyTextNormalizationToMarkdown(source, quotesOn),
+      '见图<img src="diagram.png" alt="示意图">中的“要点”。',
+    );
+  });
+
+  it('keeps fenced code and inline code quotes intact', () => {
+    const source = '正文"引用"和`const name = "易标"`。\n\n```js\nconsole.log("ok")\n```';
+    const result = applyTextNormalizationToMarkdown(source, quotesOn);
+    assert.equal(result.includes('正文“引用”'), true);
+    assert.equal(result.includes('`const name = "易标"`'), true);
+    assert.equal(result.includes('console.log("ok")'), true);
+  });
+});
+
+describe('convertChineseQuotes', () => {
+  it('does not rewrite apostrophes inside English words', () => {
+    assert.equal(convertChineseQuotes("don't"), "don't");
+  });
+});

--- a/client/src/features/duplicate-check/pages/DuplicateCheckPage.tsx
+++ b/client/src/features/duplicate-check/pages/DuplicateCheckPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { trackPageView } from '../../../shared/analytics/analytics';
-import { FloatingToolbar, isLibreOfficeRequiredMessage, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
+import { AppDialog, FloatingToolbar, isLibreOfficeRequiredMessage, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
 import type { FloatingToolbarGroup } from '../../../shared/ui';
 import type { DuplicateAnalysisStatus, DuplicateAnalysisTabId, DuplicateCheckStep, DuplicateCheckTaskState, DuplicateCheckWorkspaceState, DuplicateContentAnalysisState, DuplicateImageAnalysisState, DuplicateMetadataAnalysisState, DuplicateOutlineAnalysisState, LocalFileSelection } from '../../../shared/types';
 
@@ -605,6 +605,8 @@ function DuplicateCheckPage() {
   const [imageAnalysis, setImageAnalysis] = useState<DuplicateImageAnalysisState | undefined>();
   const [analysisTask, setAnalysisTask] = useState<DuplicateCheckTaskState | undefined>();
   const [startingAnalysis, setStartingAnalysis] = useState(false);
+  const [exportingExcel, setExportingExcel] = useState(false);
+  const [exportedExcelPath, setExportedExcelPath] = useState('');
   const [busy, setBusy] = useState<'tender' | 'bid' | null>(null);
   const [analyticsReady, setAnalyticsReady] = useState(false);
   const startedMetadataSignatureRef = useRef<string | null>(null);
@@ -919,7 +921,50 @@ function DuplicateCheckPage() {
     switchStep(nextStep);
   };
 
+  const canExportExcel = Boolean(
+    metadataAnalysis?.status === 'success'
+    || outlineAnalysis?.status === 'success'
+    || contentAnalysis?.status === 'success'
+    || imageAnalysis?.status === 'success'
+    || metadataAnalysis?.rows?.length
+    || outlineAnalysis?.duplicateGroups?.length
+    || contentAnalysis?.duplicateSentences?.length
+    || imageAnalysis?.duplicateImages?.length,
+  );
+
+  const exportExcel = async () => {
+    if (exportingExcel) return;
+    if (!canExportExcel) {
+      showToast('当前没有可导出的查重结果', 'info');
+      return;
+    }
+    setExportingExcel(true);
+    try {
+      const result = await window.yibiao?.duplicateCheck.exportExcel();
+      if (!result || result.canceled) return;
+      showToast(result.message || 'Excel 已导出', 'success');
+      if (result.path) setExportedExcelPath(result.path);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '导出 Excel 失败', 'error');
+    } finally {
+      setExportingExcel(false);
+    }
+  };
+
   const toolbarGroups: FloatingToolbarGroup[] = [
+    {
+      id: 'duplicate-check-export',
+      actions: step === 'analysis' ? [
+        {
+          id: 'export-excel',
+          label: exportingExcel ? '导出中...' : '导出 Excel',
+          variant: 'secondary',
+          disabled: exportingExcel || isAnalysisRunning || !canExportExcel,
+          tooltip: !canExportExcel ? '请先完成查重分析' : '导出元数据、目录、正文和图片查重结果',
+          onClick: () => { void exportExcel(); },
+        },
+      ] : [],
+    },
     {
       id: 'duplicate-check-reset',
       actions: [
@@ -1079,6 +1124,29 @@ function DuplicateCheckPage() {
       )}
 
       <FloatingToolbar groups={toolbarGroups} label="标书查重工具条" />
+      <AppDialog
+        open={Boolean(exportedExcelPath)}
+        onOpenChange={(open) => { if (!open) setExportedExcelPath(''); }}
+        kicker="导出完成"
+        title="是否打开 Excel"
+        description="查重结果已保存到本地，可直接打开核对。"
+        actions={(
+          <>
+            <button type="button" className="secondary-action" onClick={() => setExportedExcelPath('')}>稍后打开</button>
+            <button
+              type="button"
+              className="primary-action"
+              onClick={() => {
+                const filePath = exportedExcelPath;
+                setExportedExcelPath('');
+                if (filePath) void window.yibiao?.export.openFile(filePath);
+              }}
+            >
+              打开文件
+            </button>
+          </>
+        )}
+      />
     </div>
   );
 }

--- a/client/src/features/export-format/exportFormatPresets.ts
+++ b/client/src/features/export-format/exportFormatPresets.ts
@@ -6,6 +6,7 @@ import type {
   PageSetupConfig,
   TableCellStyleConfig,
   TableStyleConfig,
+  TextNormalizationConfig,
 } from '../../shared/types/exportFormat';
 import { DEFAULT_EXPORT_FORMAT } from '../../shared/types/exportFormat';
 
@@ -42,6 +43,9 @@ interface ExportLayoutPreset {
     body_cell: TableCellLayoutStyle;
   };
   image: ImageStyleConfig;
+  include_table_of_contents?: boolean;
+  text_normalization?: TextNormalizationConfig;
+  heading_numbering?: Array<Pick<HeadingStyleConfig, 'numbering_format' | 'numbering_template'>>;
 }
 
 interface ExportThemePreset {
@@ -69,6 +73,15 @@ const BID_HEADING_NUMBERING: Array<Pick<HeadingStyleConfig, 'numbering_format' |
   { numbering_format: 'custom', numbering_template: '{tail}' },
   { numbering_format: 'custom', numbering_template: '{tail}' },
   { numbering_format: 'custom', numbering_template: '{tail}' },
+];
+
+const EMPTY_HEADING_NUMBERING: Array<Pick<HeadingStyleConfig, 'numbering_format' | 'numbering_template'>> = [
+  { numbering_format: 'custom', numbering_template: '' },
+  { numbering_format: 'custom', numbering_template: '' },
+  { numbering_format: 'custom', numbering_template: '' },
+  { numbering_format: 'custom', numbering_template: '' },
+  { numbering_format: 'custom', numbering_template: '' },
+  { numbering_format: 'custom', numbering_template: '' },
 ];
 
 function heading(
@@ -494,6 +507,69 @@ export const EXPORT_LAYOUT_PRESETS: ExportLayoutPreset[] = [
       caption_italic: false,
     },
   },
+  {
+    id: 'anonymous-bid',
+    label: '暗标版',
+    description: '只用宋体/仿宋/黑体，关闭标题编号，打开中文引号、去空格和 Word 目录，适合暗标投标文件。',
+    page: {
+      paper_size: 'a4',
+      orientation: 'portrait',
+      first_page_different: false,
+      margin_top_cm: 2.5,
+      margin_bottom_cm: 2.5,
+      margin_left_cm: 2.8,
+      margin_right_cm: 2.6,
+      page_number_enabled: true,
+      page_number_format: '第{page}页',
+      page_number_start: 1,
+    },
+    heading_level1_page_break_before: true,
+    heading_border_enabled: false,
+    heading_border_min_heading_left_enabled: false,
+    include_table_of_contents: true,
+    text_normalization: {
+      chinese_quotes: true,
+      strip_spaces: true,
+    },
+    heading_numbering: EMPTY_HEADING_NUMBERING,
+    headings: [
+      heading('黑体', '小二', '居中对齐', true, 12, 10),
+      heading('黑体', '三号', '左对齐', true, 10, 8),
+      heading('黑体', '小三', '左对齐', true, 8, 6),
+      heading('仿宋', '四号', '左对齐', false, 6, 4),
+      heading('仿宋', '小四', '左对齐', false, 4, 3),
+      heading('宋体', '小四', '左对齐', false, 3, 2),
+    ],
+    body_text: {
+      font: '宋体',
+      size: '小四',
+      alignment: '两端对齐',
+      spacing_before_pt: 0,
+      spacing_after_pt: 0,
+      first_line_indent_chars: 2,
+      line_spacing_multiple: 1.5,
+      list_style: 'disc',
+      ordered_list_style: 'decimal-dot',
+      list_indent_chars: 2,
+    },
+    table: {
+      border_width: 1,
+      cell_padding_pt: 6,
+      full_width: true,
+      header_row: { font: '黑体', size: '小四', alignment: '居中对齐' },
+      first_column: { font: '宋体', size: '小四', alignment: '左对齐' },
+      body_cell: { font: '宋体', size: '小四', alignment: '左对齐' },
+    },
+    image: {
+      max_width_percent: 88,
+      alignment: '居中对齐',
+      caption_font: '宋体',
+      caption_size: '小五',
+      caption_alignment: '居中对齐',
+      caption_bold: false,
+      caption_italic: false,
+    },
+  },
 ];
 
 export const EXPORT_THEME_PRESETS: ExportThemePreset[] = [
@@ -671,6 +747,8 @@ export function applyExportLayoutPreset(config: ExportFormatConfig, presetId: st
   const preset = EXPORT_LAYOUT_PRESETS.find((item) => item.id === presetId);
   if (!preset) return config;
 
+  const headingNumbering = preset.heading_numbering || BID_HEADING_NUMBERING;
+
   return {
     ...config,
     page: {
@@ -683,10 +761,15 @@ export function applyExportLayoutPreset(config: ExportFormatConfig, presetId: st
       enabled: preset.heading_border_enabled,
       min_heading_left_enabled: preset.heading_border_min_heading_left_enabled,
     },
+    include_table_of_contents: preset.include_table_of_contents === true,
+    text_normalization: {
+      chinese_quotes: preset.text_normalization?.chinese_quotes === true,
+      strip_spaces: preset.text_normalization?.strip_spaces === true,
+    },
     headings: config.headings.map((current, index) => ({
       ...current,
       ...(preset.headings[index] || {}),
-      ...(BID_HEADING_NUMBERING[index] || BID_HEADING_NUMBERING[BID_HEADING_NUMBERING.length - 1]),
+      ...(headingNumbering[index] || headingNumbering[headingNumbering.length - 1] || BID_HEADING_NUMBERING[BID_HEADING_NUMBERING.length - 1]),
       text_color: current.text_color,
     })),
     body_text: {

--- a/client/src/features/export-format/pages/ExportFormatPage.tsx
+++ b/client/src/features/export-format/pages/ExportFormatPage.tsx
@@ -272,6 +272,8 @@ function createDefaultExportFormat(): ExportFormatConfig {
       body_cell: { ...DEFAULT_EXPORT_FORMAT.table.body_cell },
     },
     image: { ...DEFAULT_EXPORT_FORMAT.image },
+    text_normalization: { ...DEFAULT_EXPORT_FORMAT.text_normalization },
+    include_table_of_contents: DEFAULT_EXPORT_FORMAT.include_table_of_contents,
   };
 }
 
@@ -303,6 +305,10 @@ function withExportFormatDefaults(source: ExportFormatConfig): ExportFormatConfi
       body_cell: { ...defaults.table.body_cell, ...source.table?.body_cell },
     },
     image: { ...defaults.image, ...source.image },
+    text_normalization: { ...defaults.text_normalization, ...source.text_normalization },
+    include_table_of_contents: typeof source.include_table_of_contents === 'boolean'
+      ? source.include_table_of_contents
+      : defaults.include_table_of_contents,
   };
 }
 
@@ -878,7 +884,27 @@ function ExportFormatPage({ mode = 'create', templateId = null, onBack }: Export
         </label>
         <label className="settings-row">
           <div className="settings-row-copy"><strong>章节页框</strong><span>会导致导航窗格失效</span></div>
-          <AppSwitch checked={config.heading_border.enabled} onCheckedChange={(checked) => updateHeadingBorder({ enabled: checked })} />
+          <AppSwitch
+            checked={config.heading_border.enabled}
+            onCheckedChange={(checked) => {
+              updateHeadingBorder({ enabled: checked });
+              if (checked && config.include_table_of_contents) {
+                showToast('当前章节框线会影响目录，建议先关闭框线', 'info');
+              }
+            }}
+          />
+        </label>
+        <label className="settings-row">
+          <div className="settings-row-copy"><strong>导出目录</strong><span>在封面后插入 Word 目录域，打开文档后更新域即可出页码</span></div>
+          <AppSwitch
+            checked={config.include_table_of_contents}
+            onCheckedChange={(checked) => {
+              updateTemplate({ include_table_of_contents: checked });
+              if (checked && config.heading_border.enabled) {
+                showToast('当前章节框线会影响目录，建议先关闭框线', 'info');
+              }
+            }}
+          />
         </label>
         {config.heading_border.enabled && (
           <>
@@ -1106,6 +1132,24 @@ function ExportFormatPage({ mode = 'create', templateId = null, onBack }: Export
         <label className="settings-row">
           <div className="settings-row-copy"><strong>列表缩进（字符）</strong></div>
           <input type="number" min={0} max={10} step={0.5} value={config.body_text.list_indent_chars} onChange={(event) => updateBodyText({ list_indent_chars: Number(event.target.value) })} />
+        </label>
+        <label className="settings-row">
+          <div className="settings-row-copy"><strong>中文引号</strong><span>导出时把成对英文引号转成 “” / ‘’，数字后的小数点不转换</span></div>
+          <AppSwitch
+            checked={config.text_normalization.chinese_quotes}
+            onCheckedChange={(checked) => updateTemplate({
+              text_normalization: { ...config.text_normalization, chinese_quotes: checked },
+            })}
+          />
+        </label>
+        <label className="settings-row">
+          <div className="settings-row-copy"><strong>去掉中文空格</strong><span>导出时去掉中文之间的空格，保留英文单词和小数点</span></div>
+          <AppSwitch
+            checked={config.text_normalization.strip_spaces}
+            onCheckedChange={(checked) => updateTemplate({
+              text_normalization: { ...config.text_normalization, strip_spaces: checked },
+            })}
+          />
         </label>
       </div>
     </>

--- a/client/src/features/knowledge-base/hooks/useKnowledgeSearch.ts
+++ b/client/src/features/knowledge-base/hooks/useKnowledgeSearch.ts
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import type { KnowledgeSearchHit } from '../types';
+
+const emptyHits: KnowledgeSearchHit[] = [];
+
+export function useKnowledgeSearch(query: string, options?: { folderId?: string; enabled?: boolean; limit?: number }) {
+  const [hits, setHits] = useState<KnowledgeSearchHit[]>(emptyHits);
+  const [loading, setLoading] = useState(false);
+  const keyword = query.trim();
+  const enabled = options?.enabled !== false;
+  const folderId = options?.folderId || '';
+  const limit = options?.limit;
+
+  useEffect(() => {
+    if (!enabled || !keyword) {
+      setHits(emptyHits);
+      setLoading(false);
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    const timer = window.setTimeout(() => {
+      void window.yibiao?.knowledgeBase.search({ query: keyword, folderId: folderId || undefined, limit })
+        .then((result) => {
+          if (!cancelled) setHits(result?.results || emptyHits);
+        })
+        .catch(() => {
+          if (!cancelled) setHits(emptyHits);
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 200);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [enabled, folderId, keyword, limit]);
+
+  return { hits, loading, keyword };
+}

--- a/client/src/features/knowledge-base/pages/KnowledgeBasePage.tsx
+++ b/client/src/features/knowledge-base/pages/KnowledgeBasePage.tsx
@@ -2,7 +2,8 @@ import { Profiler, startTransition, useEffect, useLayoutEffect, useMemo, useRef,
 import * as Dialog from '@radix-ui/react-dialog';
 import { trackPageView } from '../../../shared/analytics/analytics';
 import { AppDialog, InlineSpinner, isLibreOfficeRequiredMessage, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, useDocumentParseNotice, useToast } from '../../../shared/ui';
-import type { KnowledgeAnalysisSnapshot, KnowledgeBaseIndex, KnowledgeDocument, KnowledgeItem } from '../types';
+import { useKnowledgeSearch } from '../hooks/useKnowledgeSearch';
+import type { KnowledgeAnalysisSnapshot, KnowledgeBaseIndex, KnowledgeDocument, KnowledgeItem, KnowledgeSearchHit } from '../types';
 
 declare global {
   interface Window {
@@ -293,6 +294,13 @@ function logProfilerRender(
 type KnowledgeViewer = {
   document: KnowledgeDocument;
   mode: 'analysis' | 'items' | 'markdown';
+  focusedItemId?: string;
+};
+
+const searchHitTypeLabels: Record<KnowledgeSearchHit['type'], string> = {
+  document: '文档',
+  item: '条目',
+  block: '段落',
 };
 
 function KnowledgeBasePage() {
@@ -316,6 +324,7 @@ function KnowledgeBasePage() {
   const [dragPayload, setDragPayload] = useState<KnowledgeDragPayload | null>(null);
   const [folderDropTargetId, setFolderDropTargetId] = useState<string | null>(null);
   const [documentDropTarget, setDocumentDropTarget] = useState<KnowledgeDocumentDropTarget | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
   const [dragSaving, setDragSaving] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState<
     | { type: 'folder'; folderId: string; folderName: string; count: number }
@@ -345,6 +354,7 @@ function KnowledgeBasePage() {
   }, [index.documents]);
   const documents = activeFolder ? documentsByFolder.get(activeFolder.id) || emptyDocuments : emptyDocuments;
   const visibleDocuments = documents.slice(0, Math.min(visibleDocumentCount, documents.length));
+  const { hits: searchHits, loading: searchLoading, keyword: searchKeyword } = useKnowledgeSearch(searchQuery);
 
   useEffect(() => {
     trackPageView(viewer ? `knowledge-base/viewer/${viewer.mode}` : 'knowledge-base/library');
@@ -746,7 +756,7 @@ function KnowledgeBasePage() {
     return trace;
   };
 
-  const openDocument = async (document: KnowledgeDocument, mode: KnowledgeViewer['mode']) => {
+  const openDocument = async (document: KnowledgeDocument, mode: KnowledgeViewer['mode'], focusedItemId?: string) => {
     if (mode === 'analysis' && !developerMode) {
       return;
     }
@@ -756,7 +766,7 @@ function KnowledgeBasePage() {
     setViewerLoading(mode !== 'analysis');
     logRenderDebug(trace, 'state:loading-start', { loading: mode !== 'analysis' });
     startTransition(() => {
-      setViewer({ document, mode });
+      setViewer({ document, mode, focusedItemId });
       setMarkdownPreview('');
       setItemsPreview([]);
       if (mode === 'analysis') {
@@ -825,6 +835,16 @@ function KnowledgeBasePage() {
     }
   };
 
+  const openSearchHit = (hit: KnowledgeSearchHit) => {
+    const document = index.documents.find((item) => item.id === hit.documentId);
+    if (!document) {
+      showToast('未找到对应知识库文档', 'info');
+      return;
+    }
+    setActiveFolderId(hit.folderId || document.folder_id);
+    void openDocument(document, hit.type === 'block' ? 'markdown' : 'items', hit.itemId);
+  };
+
   const closeViewer = () => {
     viewerRequestIdRef.current += 1;
     finishActiveViewerTrace('viewer-closed');
@@ -864,6 +884,7 @@ function KnowledgeBasePage() {
         <KnowledgeDocumentViewer
           document={viewer.document}
           mode={viewer.mode}
+          focusedItemId={viewer.focusedItemId}
           itemsPreview={itemsPreview}
           markdownPreview={markdownPreview}
           analysisSnapshot={analysisSnapshot}
@@ -890,6 +911,13 @@ function KnowledgeBasePage() {
           <small>{index.folders.length} 个文件夹 / {index.documents.length} 个文档</small>
         </div>
         <div className="knowledge-toolbar-actions">
+          <input
+            className="knowledge-search-input"
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="搜索文档、条目或正文"
+            aria-label="搜索知识库"
+          />
           <button type="button" className="secondary-action" onClick={() => setShowCreateFolder((value) => !value)} disabled={listLoading}>新建文件夹</button>
           <button type="button" className="primary-action" onClick={uploadDocuments} disabled={loading || !activeFolder}>
             {loading ? '处理中...' : '上传文档'}
@@ -983,11 +1011,39 @@ function KnowledgeBasePage() {
 
         <main className="knowledge-document-panel">
           <div className="knowledge-panel-head">
-            <strong>{activeFolder?.name || '未选择文件夹'}</strong>
-            <span>{documents.length} 个文档</span>
+            <strong>{searchKeyword ? '检索结果' : activeFolder?.name || '未选择文件夹'}</strong>
+            <span>{searchKeyword ? `${searchHits.length} 条` : `${documents.length} 个文档`}</span>
           </div>
 
-          {listLoading ? (
+          {searchKeyword ? (
+            searchLoading ? (
+              <div className="knowledge-empty-box large">
+                <strong>正在检索知识库...</strong>
+                <p>会同时匹配文档名、知识条目和正文段落。</p>
+              </div>
+            ) : searchHits.length ? (
+              <div className="knowledge-search-results">
+                {searchHits.map((hit) => (
+                  <button
+                    type="button"
+                    className="knowledge-search-hit"
+                    key={`${hit.type}-${hit.documentId}-${hit.itemId || hit.blockId || 'doc'}`}
+                    onClick={() => openSearchHit(hit)}
+                  >
+                    <span className="knowledge-search-hit-type">{searchHitTypeLabels[hit.type]}</span>
+                    <strong>{hit.title}</strong>
+                    <small>{[hit.folderName, hit.fileName].filter(Boolean).join(' / ')}</small>
+                    {hit.snippet ? <p>{hit.snippet}</p> : null}
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="knowledge-empty-box large">
+                <strong>没有匹配的知识内容</strong>
+                <p>可换个关键词，或先到其他文件夹上传并处理完成后再搜。</p>
+              </div>
+            )
+          ) : listLoading ? (
             <div className="knowledge-empty-box large">
               <strong>正在读取知识库...</strong>
               <p>文档列表加载完成后会自动显示。</p>
@@ -1086,6 +1142,7 @@ function KnowledgeBasePage() {
 interface KnowledgeDocumentViewerProps {
   document: KnowledgeDocument;
   mode: KnowledgeViewer['mode'];
+  focusedItemId?: string;
   itemsPreview: KnowledgeItem[];
   markdownPreview: string;
   analysisSnapshot: KnowledgeAnalysisSnapshot | null;
@@ -1102,6 +1159,7 @@ interface KnowledgeDocumentViewerProps {
 function KnowledgeDocumentViewer({
   document,
   mode,
+  focusedItemId,
   itemsPreview,
   markdownPreview,
   analysisSnapshot,
@@ -1218,6 +1276,7 @@ function KnowledgeDocumentViewer({
                 <KnowledgeItemCard
                   key={item.id}
                   item={item}
+                  focused={item.id === focusedItemId}
                   developerMode={developerMode}
                   onOpenSource={() => openSourceItem(item)}
                 />
@@ -1276,13 +1335,22 @@ function KnowledgeDocumentViewer({
 
 interface KnowledgeItemCardProps {
   item: KnowledgeItem;
+  focused?: boolean;
   developerMode: boolean;
   onOpenSource: () => void;
 }
 
-function KnowledgeItemCard({ item, developerMode, onOpenSource }: KnowledgeItemCardProps) {
+function KnowledgeItemCard({ item, focused, developerMode, onOpenSource }: KnowledgeItemCardProps) {
+  const cardRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (focused) {
+      cardRef.current?.scrollIntoView({ block: 'center' });
+    }
+  }, [focused]);
+
   return (
-    <article className="knowledge-item-card">
+    <article ref={cardRef} className={`knowledge-item-card${focused ? ' is-focused' : ''}`} id={`knowledge-item-${item.id}`}>
       {developerMode && <code className="knowledge-entity-id">条目ID：{item.id}</code>}
       <strong>{item.title}</strong>
       <p>{item.resume}</p>

--- a/client/src/features/knowledge-base/types.ts
+++ b/client/src/features/knowledge-base/types.ts
@@ -115,3 +115,27 @@ export interface KnowledgeBaseUploadResult {
 export interface KnowledgeBaseEvent {
   document: KnowledgeDocument;
 }
+
+export type KnowledgeSearchHitType = 'document' | 'item' | 'block';
+
+export interface KnowledgeSearchHit {
+  type: KnowledgeSearchHitType;
+  documentId: string;
+  folderId: string;
+  folderName: string;
+  fileName: string;
+  itemId?: string;
+  blockId?: string;
+  title: string;
+  snippet: string;
+}
+
+export interface KnowledgeSearchRequest {
+  query: string;
+  folderId?: string;
+  limit?: number;
+}
+
+export interface KnowledgeSearchResult {
+  results: KnowledgeSearchHit[];
+}

--- a/client/src/features/rejection-check/pages/RejectionCheckPage.tsx
+++ b/client/src/features/rejection-check/pages/RejectionCheckPage.tsx
@@ -1,9 +1,12 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { trackPageView } from '../../../shared/analytics/analytics';
-import { AppSwitch, FloatingToolbar, isLibreOfficeRequiredMessage, MarkdownEditor, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
+import { AppDialog, AppSwitch, FloatingToolbar, isLibreOfficeRequiredMessage, MarkdownEditor, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
 import type { FloatingToolbarGroup } from '../../../shared/ui';
 import type {
+  IdentityCheckCategory,
+  IdentityCheckFinding,
+  IdentityCheckResultState,
   LogicCheckFinding,
   LogicCheckResultState,
   RejectionBackgroundTaskState,
@@ -36,18 +39,44 @@ const stepLabels: Record<RejectionCheckStep, string> = {
 const resultTabs: Array<{ id: RejectionResultTab; label: string }> = [
   { id: 'analysis', label: '解析结果' },
   { id: 'custom', label: '自定义检查项' },
+  { id: 'identity', label: '暗标补充词' },
 ];
 
 const checkResultTabs: Array<{ id: RejectionCheckResultTab; label: string; description: string }> = [
   { id: 'rejection', label: '废标项检查', description: '根据无效与废标项检查投标文件响应风险' },
   { id: 'typo', label: '错别字检查', description: '检查投标文件中的错别字和明显文字错误' },
   { id: 'logic', label: '逻辑谬误检查', description: '检查前后矛盾、逻辑不一致和表达漏洞' },
+  { id: 'identity', label: '暗标', description: '检查投标文件中可能暴露身份的暗标风险' },
 ];
 
 const defaultCheckOptions: RejectionCheckOptions = {
   rejectionCheck: true,
   typoCheck: true,
   logicCheck: true,
+  identityCheck: true,
+};
+
+const identityBuiltinChecklist = [
+  '人名或简称',
+  '单位 / 企业 / 公司名称',
+  '非本项目的工程名、项目名、项目编号、标段号',
+  '历史项目或业绩举例',
+  '联系方式',
+  '非完整句子的特殊符号',
+  '地区名称',
+  '英文标点、英文字母、英文单位',
+  '用户补充词',
+];
+
+const identityCategoryLabels: Record<IdentityCheckCategory, string> = {
+  person: '人名或简称',
+  org: '单位名称',
+  project: '项目或编号',
+  contact: '联系方式',
+  region: '地区名称',
+  english: '英文或单位',
+  punctuation: '英文标点或符号',
+  custom: '补充词',
 };
 
 const documentLabels: Record<RejectionDocumentRole, string> = {
@@ -108,6 +137,10 @@ function createEmptyLogicCheckResultState(): LogicCheckResultState {
   return { status: 'idle', findings: [] };
 }
 
+function createEmptyIdentityCheckResultState(): IdentityCheckResultState {
+  return { status: 'idle', findings: [] };
+}
+
 function normalizeBackgroundTaskState(state?: Partial<RejectionBackgroundTaskState> | null): RejectionBackgroundTaskState | undefined {
   if (!state || typeof state !== 'object') return undefined;
   const type = state.type === 'rejection-items-extraction' || state.type === 'rejection-check-run' ? state.type : undefined;
@@ -131,13 +164,15 @@ function normalizeCheckOptions(options?: Partial<RejectionCheckOptions> | null):
     rejectionCheck: true,
     typoCheck: options?.typoCheck !== false,
     logicCheck: options?.logicCheck !== false,
+    identityCheck: options?.identityCheck !== false,
   };
 }
 
 function isCheckResultTabEnabled(tabId: RejectionCheckResultTab, options: RejectionCheckOptions) {
   if (tabId === 'rejection') return options.rejectionCheck;
   if (tabId === 'typo') return options.typoCheck;
-  return options.logicCheck;
+  if (tabId === 'logic') return options.logicCheck;
+  return options.identityCheck;
 }
 
 function getCheckResultTabProgress(status: RejectionCheckTabStatus, progressMessage?: string) {
@@ -278,6 +313,59 @@ function normalizeLogicCheckResultState(state?: Partial<LogicCheckResultState> |
     findings,
     activeFindingId,
   };
+}
+
+function normalizeIdentityFindingState(item: Partial<IdentityCheckFinding> | null | undefined, index: number): IdentityCheckFinding | null {
+  if (!item) return null;
+  const matchedText = typeof item.matchedText === 'string' ? item.matchedText.trim() : '';
+  const riskReason = typeof item.riskReason === 'string' ? item.riskReason.trim() : '';
+  if (!matchedText || !riskReason) return null;
+  const category = (['person', 'org', 'project', 'contact', 'region', 'english', 'punctuation', 'custom'] as IdentityCheckCategory[])
+    .includes(item.category as IdentityCheckCategory)
+    ? item.category as IdentityCheckCategory
+    : 'custom';
+
+  return {
+    id: typeof item.id === 'string' && item.id.trim() ? item.id.trim() : `identity-finding-${index + 1}`,
+    bidDocumentId: typeof item.bidDocumentId === 'string' && item.bidDocumentId.trim() ? item.bidDocumentId.trim() : '',
+    category,
+    matchedText,
+    originalExcerpt: typeof item.originalExcerpt === 'string' && item.originalExcerpt.trim() ? item.originalExcerpt.trim() : matchedText,
+    locationHint: typeof item.locationHint === 'string' && item.locationHint.trim() ? item.locationHint.trim() : '未明确具体位置，请结合原文摘录复核。',
+    riskReason,
+    suggestion: typeof item.suggestion === 'string' && item.suggestion.trim() ? item.suggestion.trim() : '请删除或改写为不暴露投标人身份的表述。',
+  };
+}
+
+function normalizeIdentityCheckResultState(state?: Partial<IdentityCheckResultState> | null): IdentityCheckResultState {
+  if (!state) {
+    return createEmptyIdentityCheckResultState();
+  }
+
+  const findings = Array.isArray(state.findings)
+    ? state.findings.map((item, index) => normalizeIdentityFindingState(item, index)).filter((item): item is IdentityCheckFinding => Boolean(item))
+    : [];
+  const status = ['idle', 'running', 'success', 'error'].includes(state.status || '') ? state.status : 'idle';
+  const activeFindingId = findings.some((item) => item.id === state.activeFindingId) ? state.activeFindingId : undefined;
+
+  return {
+    ...state,
+    status: status as RejectionCheckRunStatus,
+    findings,
+    activeFindingId,
+  };
+}
+
+function createIdentityCheckInputSignature(bidDocuments: RejectionDocumentContent[], identityExtraKeywords: string) {
+  const bidSignature = bidDocuments.map(createDocumentSignature).filter(Boolean).join('\n---yibiao-rejection-bid-document---\n');
+  if (!bidSignature) return '';
+  const extra = identityExtraKeywords.trim();
+  return [
+    bidSignature,
+    extra.length,
+    extra.slice(0, 800),
+    extra.slice(-800),
+  ].join('\n---yibiao-identity-check-input---\n');
 }
 
 function formatCharacterCount(length: number) {
@@ -557,6 +645,42 @@ function LogicFindingItem({ finding, bidLabel, expanded, onToggle, onDelete }: {
   );
 }
 
+function IdentityFindingItem({ finding, bidLabel, expanded, onToggle, onDelete }: { finding: IdentityCheckFinding; bidLabel: string; expanded: boolean; onToggle: () => void; onDelete: () => void }) {
+  return (
+    <article className={`rejection-finding-item is-identity is-${finding.category}${expanded ? ' is-expanded' : ''}`}>
+      <div className="rejection-finding-row">
+        <button
+          type="button"
+          className="rejection-finding-toggle"
+          onClick={onToggle}
+          aria-expanded={expanded}
+        >
+          <span className="rejection-finding-chevron" aria-hidden="true">{expanded ? '-' : '+'}</span>
+          <span className="rejection-finding-title-wrap">
+            <span>
+              <strong>{finding.matchedText}</strong>
+              <em className="rejection-finding-file-tag">{bidLabel}</em>
+              <em className="rejection-finding-tag is-identity">{identityCategoryLabels[finding.category]}</em>
+            </span>
+            <small>{finding.locationHint}</small>
+          </span>
+        </button>
+        <button type="button" className="rejection-finding-delete" onClick={onDelete} aria-label={`删除${finding.matchedText}`}>
+          删除
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="rejection-finding-detail">
+          <FindingDetailBlock label="原文摘录" content={finding.originalExcerpt} />
+          <FindingDetailBlock label="风险原因" content={finding.riskReason} />
+          <FindingDetailBlock label="修改建议" content={finding.suggestion} />
+        </div>
+      )}
+    </article>
+  );
+}
+
 function RejectionCheckPage() {
   const [step, setStep] = useState<RejectionCheckStep>('documents');
   const [tenderDocument, setTenderDocument] = useState<RejectionDocumentContent | null>(null);
@@ -570,14 +694,20 @@ function RejectionCheckPage() {
   const [rejectionCheckResult, setRejectionCheckResult] = useState<RejectionCheckResultState>(() => createEmptyRejectionCheckResultState());
   const [typoCheckResult, setTypoCheckResult] = useState<TypoCheckResultState>(() => createEmptyTypoCheckResultState());
   const [logicCheckResult, setLogicCheckResult] = useState<LogicCheckResultState>(() => createEmptyLogicCheckResultState());
+  const [identityCheckResult, setIdentityCheckResult] = useState<IdentityCheckResultState>(() => createEmptyIdentityCheckResultState());
   const [extractionTask, setExtractionTask] = useState<RejectionBackgroundTaskState | undefined>();
   const [checkTask, setCheckTask] = useState<RejectionBackgroundTaskState | undefined>();
   const [customCheckItems, setCustomCheckItems] = useState('');
   const [customCheckItemsDraft, setCustomCheckItemsDraft] = useState('');
   const [customCheckItemsSaving, setCustomCheckItemsSaving] = useState(false);
+  const [identityExtraKeywords, setIdentityExtraKeywords] = useState('');
+  const [identityExtraKeywordsDraft, setIdentityExtraKeywordsDraft] = useState('');
+  const [identityExtraKeywordsSaving, setIdentityExtraKeywordsSaving] = useState(false);
   const [checkOptions, setCheckOptions] = useState<RejectionCheckOptions>(defaultCheckOptions);
   const [draftCheckOptions, setDraftCheckOptions] = useState<RejectionCheckOptions>(defaultCheckOptions);
   const [checkConfigDialogOpen, setCheckConfigDialogOpen] = useState(false);
+  const [exportingExcel, setExportingExcel] = useState(false);
+  const [exportedExcelPath, setExportedExcelPath] = useState('');
   const [busy, setBusy] = useState<'technical-plan' | 'tender-upload' | 'bid-upload' | 'remove' | null>(null);
   const [analyticsReady, setAnalyticsReady] = useState(false);
   const hydratedRef = useRef(false);
@@ -586,6 +716,9 @@ function RejectionCheckPage() {
   const customCheckItemsRef = useRef('');
   const customCheckItemsDraftRef = useRef('');
   const customCheckItemsSaveVersionRef = useRef(0);
+  const identityExtraKeywordsRef = useRef('');
+  const identityExtraKeywordsDraftRef = useRef('');
+  const identityExtraKeywordsSaveVersionRef = useRef(0);
   const { showToast } = useToast();
   const { showDocumentParseNotice } = useDocumentParseNotice();
 
@@ -596,7 +729,8 @@ function RejectionCheckPage() {
   const bidSignature = useMemo(() => createBidDocumentsSignature(bidDocuments), [bidDocuments]);
   const hasAnyDocument = Boolean(tenderDocument || bidDocuments.length);
   const checkOptionsChanged = checkOptions.typoCheck !== defaultCheckOptions.typoCheck
-    || checkOptions.logicCheck !== defaultCheckOptions.logicCheck;
+    || checkOptions.logicCheck !== defaultCheckOptions.logicCheck
+    || checkOptions.identityCheck !== defaultCheckOptions.identityCheck;
   const hasAnyWorkspaceData = Boolean(
     hasAnyDocument
     || invalidBidAndRejectionItems.content.trim()
@@ -606,9 +740,12 @@ function RejectionCheckPage() {
     || typoCheckResult.findings.length
     || logicCheckResult.status !== 'idle'
     || logicCheckResult.findings.length
+    || identityCheckResult.status !== 'idle'
+    || identityCheckResult.findings.length
     || extractionTask
     || checkTask
     || customCheckItemsDraft.trim()
+    || identityExtraKeywordsDraft.trim()
     || checkOptionsChanged,
   );
   const canGoNext = Boolean(tenderDocument && bidDocuments.length);
@@ -644,20 +781,33 @@ function RejectionCheckPage() {
     bidSignature
     && logicCheckResult.inputSignature === bidSignature,
   );
+  const currentIdentityCheckInputSignature = useMemo(
+    () => createIdentityCheckInputSignature(bidDocuments, identityExtraKeywords),
+    [bidDocuments, identityExtraKeywords],
+  );
+  const identityCheckMatchesInput = Boolean(
+    currentIdentityCheckInputSignature
+    && identityCheckResult.inputSignature === currentIdentityCheckInputSignature,
+  );
   const visibleRejectionCheckStatus: RejectionCheckRunStatus = rejectionCheckMatchesInput ? rejectionCheckResult.status : 'idle';
   const visibleRejectionFindings = rejectionCheckMatchesInput ? rejectionCheckResult.findings : [];
   const visibleTypoCheckStatus: RejectionCheckRunStatus = typoCheckMatchesInput ? typoCheckResult.status : 'idle';
   const visibleTypoFindings = typoCheckMatchesInput ? typoCheckResult.findings : [];
   const visibleLogicCheckStatus: RejectionCheckRunStatus = logicCheckMatchesInput ? logicCheckResult.status : 'idle';
   const visibleLogicFindings = logicCheckMatchesInput ? logicCheckResult.findings : [];
+  const visibleIdentityCheckStatus: RejectionCheckRunStatus = identityCheckMatchesInput ? identityCheckResult.status : 'idle';
+  const visibleIdentityFindings = identityCheckMatchesInput ? identityCheckResult.findings : [];
   const rejectionCheckRunning = rejectionCheckResult.status === 'running';
   const typoCheckRunning = typoCheckResult.status === 'running';
   const logicCheckRunning = logicCheckResult.status === 'running';
+  const identityCheckRunning = identityCheckResult.status === 'running';
   const backgroundCheckRunning = checkTask?.status === 'running';
-  const checkRunning = rejectionCheckRunning || typoCheckRunning || logicCheckRunning || backgroundCheckRunning;
+  const checkRunning = rejectionCheckRunning || typoCheckRunning || logicCheckRunning || identityCheckRunning || backgroundCheckRunning;
   const documentsLocked = busy !== null || extractionRunning || checkRunning;
   const customCheckItemsDirty = customCheckItemsDraft !== customCheckItems;
   const customCheckItemsDisabled = extractionRunning || checkRunning || customCheckItemsSaving;
+  const identityExtraKeywordsDirty = identityExtraKeywordsDraft !== identityExtraKeywords;
+  const identityExtraKeywordsDisabled = extractionRunning || checkRunning || identityExtraKeywordsSaving;
   const hasStaleRejectionCheckResult = Boolean(
     currentRejectionCheckInputSignature
     && rejectionCheckResult.inputSignature
@@ -675,6 +825,12 @@ function RejectionCheckPage() {
     && logicCheckResult.inputSignature
     && logicCheckResult.inputSignature !== bidSignature
     && (logicCheckResult.findings.length || logicCheckResult.status !== 'idle'),
+  );
+  const hasStaleIdentityCheckResult = Boolean(
+    currentIdentityCheckInputSignature
+    && identityCheckResult.inputSignature
+    && identityCheckResult.inputSignature !== currentIdentityCheckInputSignature
+    && (identityCheckResult.findings.length || identityCheckResult.status !== 'idle'),
   );
 
   useEffect(() => {
@@ -704,6 +860,22 @@ function RejectionCheckPage() {
     setCustomCheckItemsDraft(value);
   }
 
+  function syncIdentityExtraKeywordsFromWorkspace(value: unknown) {
+    const nextValue = typeof value === 'string' ? value : '';
+    const shouldSyncDraft = identityExtraKeywordsDraftRef.current === identityExtraKeywordsRef.current;
+    identityExtraKeywordsRef.current = nextValue;
+    setIdentityExtraKeywords(nextValue);
+    if (shouldSyncDraft) {
+      identityExtraKeywordsDraftRef.current = nextValue;
+      setIdentityExtraKeywordsDraft(nextValue);
+    }
+  }
+
+  function updateIdentityExtraKeywordsDraft(value: string) {
+    identityExtraKeywordsDraftRef.current = value;
+    setIdentityExtraKeywordsDraft(value);
+  }
+
   function applyWorkspaceState(state: RejectionCheckWorkspaceState, options: { syncViewState?: boolean } = {}) {
     const syncViewState = options.syncViewState !== false;
     setTenderDocument(state.tenderDocument || null);
@@ -719,7 +891,7 @@ function RejectionCheckPage() {
         : 'tender';
       setActiveDocumentTab(nextActiveDocumentTab);
       setStep(state.step === 'items' || state.step === 'results' ? state.step : 'documents');
-      setActiveResultTab(state.activeResultTab === 'custom' ? 'custom' : 'analysis');
+      setActiveResultTab(state.activeResultTab === 'custom' || state.activeResultTab === 'identity' ? state.activeResultTab : 'analysis');
       setActiveCheckResultTab(checkResultTabs.some((tab) => tab.id === state.activeCheckResultTab) ? state.activeCheckResultTab as RejectionCheckResultTab : 'rejection');
     }
     setInvalidBidAndRejectionItems(normalizeExtractionState({
@@ -729,9 +901,11 @@ function RejectionCheckPage() {
     setRejectionCheckResult(normalizeRejectionCheckResultState(state.rejectionCheckResult));
     setTypoCheckResult(normalizeTypoCheckResultState(state.typoCheckResult));
     setLogicCheckResult(normalizeLogicCheckResultState(state.logicCheckResult));
+    setIdentityCheckResult(normalizeIdentityCheckResultState(state.identityCheckResult));
     setExtractionTask(normalizeBackgroundTaskState(state.extractionTask));
     setCheckTask(normalizeBackgroundTaskState(state.checkTask));
     syncCustomCheckItemsFromWorkspace(state.customCheckItems);
+    syncIdentityExtraKeywordsFromWorkspace(state.identityExtraKeywords);
     const nextOptions = normalizeCheckOptions(state.checkOptions);
     setCheckOptions(nextOptions);
     setDraftCheckOptions(nextOptions);
@@ -763,9 +937,15 @@ function RejectionCheckPage() {
         ? createEmptyLogicCheckResultState()
         : normalizeLogicCheckResultState({ ...prev, ...patch.logicCheckResult }));
     }
+    if (has('identityCheckResult')) {
+      setIdentityCheckResult((prev) => patch.identityCheckResult === undefined
+        ? createEmptyIdentityCheckResultState()
+        : normalizeIdentityCheckResultState({ ...prev, ...patch.identityCheckResult }));
+    }
     if (has('extractionTask')) setExtractionTask(normalizeBackgroundTaskState(patch.extractionTask));
     if (has('checkTask')) setCheckTask(normalizeBackgroundTaskState(patch.checkTask));
     if (has('customCheckItems')) syncCustomCheckItemsFromWorkspace(patch.customCheckItems);
+    if (has('identityExtraKeywords')) syncIdentityExtraKeywordsFromWorkspace(patch.identityExtraKeywords);
     if (has('checkOptions')) {
       const nextOptions = normalizeCheckOptions(patch.checkOptions);
       setCheckOptions(nextOptions);
@@ -1047,6 +1227,7 @@ function RejectionCheckPage() {
     setRejectionCheckResult(createEmptyRejectionCheckResultState());
     setTypoCheckResult(createEmptyTypoCheckResultState());
     setLogicCheckResult(createEmptyLogicCheckResultState());
+    setIdentityCheckResult(createEmptyIdentityCheckResultState());
     setExtractionTask(undefined);
     setCheckTask(undefined);
     customCheckItemsRef.current = '';
@@ -1054,6 +1235,12 @@ function RejectionCheckPage() {
     setCustomCheckItems('');
     setCustomCheckItemsDraft('');
     setCustomCheckItemsSaving(false);
+    identityExtraKeywordsSaveVersionRef.current += 1;
+    identityExtraKeywordsRef.current = '';
+    identityExtraKeywordsDraftRef.current = '';
+    setIdentityExtraKeywords('');
+    setIdentityExtraKeywordsDraft('');
+    setIdentityExtraKeywordsSaving(false);
     setCheckOptions(defaultCheckOptions);
     setDraftCheckOptions(defaultCheckOptions);
     setCheckConfigDialogOpen(false);
@@ -1130,12 +1317,61 @@ function RejectionCheckPage() {
     return false;
   }
 
+  async function saveIdentityExtraKeywords() {
+    if (!identityExtraKeywordsDirty || identityExtraKeywordsDisabled) {
+      return;
+    }
+
+    const saveUiState = window.yibiao?.rejectionCheck.saveUiState;
+    if (typeof saveUiState !== 'function') {
+      showToast('废标项检查缓存接口尚未加载，请重启应用后重试', 'error');
+      return;
+    }
+
+    const nextKeywords = identityExtraKeywordsDraftRef.current;
+    const saveVersion = ++identityExtraKeywordsSaveVersionRef.current;
+    try {
+      setIdentityExtraKeywordsSaving(true);
+      await saveUiState({ identityExtraKeywords: nextKeywords });
+      if (saveVersion !== identityExtraKeywordsSaveVersionRef.current) {
+        return;
+      }
+      identityExtraKeywordsRef.current = nextKeywords;
+      setIdentityExtraKeywords(nextKeywords);
+      showToast('暗标补充词已保存', 'success');
+    } catch (error) {
+      if (saveVersion !== identityExtraKeywordsSaveVersionRef.current) {
+        return;
+      }
+      showToast(error instanceof Error ? error.message : '保存暗标补充词失败', 'error');
+    } finally {
+      if (saveVersion === identityExtraKeywordsSaveVersionRef.current) {
+        setIdentityExtraKeywordsSaving(false);
+      }
+    }
+  }
+
+  function ensureIdentityExtraKeywordsSaved() {
+    if (!identityExtraKeywordsDirty) {
+      return true;
+    }
+
+    setStep('items');
+    setActiveResultTab('identity');
+    showToast('暗标补充词有未保存修改，请先保存', 'info');
+    return false;
+  }
+
   async function startChecks(options: RejectionCheckOptions = checkOptions, runOptions: RejectionCheckOptions = options) {
     if (checkRunning) {
       return;
     }
 
     if (!ensureCustomCheckItemsSaved()) {
+      return;
+    }
+
+    if (!ensureIdentityExtraKeywordsSaved()) {
       return;
     }
 
@@ -1155,12 +1391,18 @@ function RejectionCheckPage() {
       return;
     }
 
-    if (!runOptions.rejectionCheck && !runOptions.typoCheck && !runOptions.logicCheck) {
+    if (!runOptions.rejectionCheck && !runOptions.typoCheck && !runOptions.logicCheck && !runOptions.identityCheck) {
       showToast('请至少启用一种检查', 'info');
       return;
     }
 
-    const nextActiveCheckResultTab: RejectionCheckResultTab = runOptions.rejectionCheck ? 'rejection' : runOptions.typoCheck ? 'typo' : 'logic';
+    const nextActiveCheckResultTab: RejectionCheckResultTab = runOptions.rejectionCheck
+      ? 'rejection'
+      : runOptions.typoCheck
+        ? 'typo'
+        : runOptions.logicCheck
+          ? 'logic'
+          : 'identity';
     setActiveCheckResultTab(nextActiveCheckResultTab);
     setActiveResultBidDocumentId('all');
     const startedAt = new Date().toISOString();
@@ -1191,6 +1433,15 @@ function RejectionCheckPage() {
           updatedAt: startedAt,
         }
       : logicCheckResult;
+    const nextIdentityCheckResult: IdentityCheckResultState = runOptions.identityCheck
+      ? {
+          status: 'running',
+          findings: [],
+          inputSignature: currentIdentityCheckInputSignature,
+          progressMessage: '第一轮：正在分析暗标检查范围。',
+          updatedAt: startedAt,
+        }
+      : identityCheckResult;
     const nextCheckTask: RejectionBackgroundTaskState = {
       task_id: `local-${Date.now()}`,
       type: 'rejection-check-run',
@@ -1213,6 +1464,10 @@ function RejectionCheckPage() {
       setLogicCheckResult(nextLogicCheckResult);
     }
 
+    if (runOptions.identityCheck) {
+      setIdentityCheckResult(nextIdentityCheckResult);
+    }
+
     setCheckTask(nextCheckTask);
 
     try {
@@ -1230,6 +1485,7 @@ function RejectionCheckPage() {
         checkOptions: options,
         runOptions,
         customCheckItems,
+        identityExtraKeywords,
       });
       showToast('检查任务已在后台启动', 'success');
     } catch (error) {
@@ -1246,6 +1502,11 @@ function RejectionCheckPage() {
       }
       if (runOptions.logicCheck) {
         setLogicCheckResult((prev) => prev.inputSignature === bidSignature
+          ? { ...prev, status: 'error', error: message, progressMessage: message, updatedAt: new Date().toISOString() }
+          : prev);
+      }
+      if (runOptions.identityCheck) {
+        setIdentityCheckResult((prev) => prev.inputSignature === currentIdentityCheckInputSignature
           ? { ...prev, status: 'error', error: message, progressMessage: message, updatedAt: new Date().toISOString() }
           : prev);
       }
@@ -1266,6 +1527,7 @@ function RejectionCheckPage() {
       rejectionCheck: tabId === 'rejection',
       typoCheck: tabId === 'typo',
       logicCheck: tabId === 'logic',
+      identityCheck: tabId === 'identity',
     });
   }
 
@@ -1383,6 +1645,38 @@ function RejectionCheckPage() {
     }, '保存逻辑谬误结果状态失败');
   }
 
+  function toggleIdentityFinding(findingId: string) {
+    const next = {
+      ...identityCheckResult,
+      activeFindingId: identityCheckResult.activeFindingId === findingId ? undefined : findingId,
+      updatedAt: new Date().toISOString(),
+    };
+    setIdentityCheckResult(next);
+    persistRejectionState({
+      identityCheckResult: { activeFindingId: next.activeFindingId, updatedAt: next.updatedAt },
+    }, '保存暗标检查结果状态失败');
+  }
+
+  function deleteIdentityFinding(findingId: string) {
+    const findings = identityCheckResult.findings.filter((item) => item.id !== findingId);
+    const next = {
+      ...identityCheckResult,
+      findings,
+      activeFindingId: identityCheckResult.activeFindingId === findingId ? undefined : identityCheckResult.activeFindingId,
+      progressMessage: findings.length ? `保留 ${findings.length} 个暗标风险` : '所有暗标风险已处理',
+      updatedAt: new Date().toISOString(),
+    };
+    setIdentityCheckResult(next);
+    persistRejectionState({
+      identityCheckResult: {
+        findings,
+        activeFindingId: next.activeFindingId,
+        progressMessage: next.progressMessage,
+        updatedAt: next.updatedAt,
+      },
+    }, '保存暗标检查结果状态失败');
+  }
+
   function markStaleTasksWithoutActive(activeTypes: Set<string>) {
     if (!activeTypes.has('rejection-items-extraction')) {
       markStaleExtractionTask();
@@ -1415,7 +1709,7 @@ function RejectionCheckPage() {
 
   function markStaleCheckTask() {
     const staleMessage = '上次检查未完成，请重新检查';
-    const markResult = <T extends RejectionCheckResultState | TypoCheckResultState | LogicCheckResultState>(prev: T): T => (prev.status === 'running'
+    const markResult = <T extends RejectionCheckResultState | TypoCheckResultState | LogicCheckResultState | IdentityCheckResultState>(prev: T): T => (prev.status === 'running'
       ? {
           ...prev,
           status: 'error',
@@ -1427,6 +1721,7 @@ function RejectionCheckPage() {
     setRejectionCheckResult(markResult);
     setTypoCheckResult(markResult);
     setLogicCheckResult(markResult);
+    setIdentityCheckResult(markResult);
     setCheckTask((prev) => prev?.status === 'running'
       ? {
           ...prev,
@@ -1440,7 +1735,7 @@ function RejectionCheckPage() {
   }
 
   function switchStep(nextStep: RejectionCheckStep) {
-    if (nextStep !== step && !ensureCustomCheckItemsSaved()) {
+    if (nextStep !== step && (!ensureCustomCheckItemsSaved() || !ensureIdentityExtraKeywordsSaved())) {
       return;
     }
     if (nextStep === 'items' && !canGoNext) {
@@ -1462,7 +1757,9 @@ function RejectionCheckPage() {
     || visibleTypoCheckStatus === 'success'
     || visibleTypoCheckStatus === 'error'
     || visibleLogicCheckStatus === 'success'
-    || visibleLogicCheckStatus === 'error';
+    || visibleLogicCheckStatus === 'error'
+    || visibleIdentityCheckStatus === 'success'
+    || visibleIdentityCheckStatus === 'error';
   const checkActionLabel = checkRunning
     ? '检查中...'
     : hasVisibleCheckResult
@@ -1501,6 +1798,17 @@ function RejectionCheckPage() {
         : hasStaleLogicCheckResult
           ? '投标文件已变化，请重新检查以刷新结果。'
           : '点击开始检查后展示逻辑谬误检查结果。';
+  const identityCheckSummaryText = visibleIdentityCheckStatus === 'running'
+    ? identityCheckResult.progressMessage || 'AI 正在检查暗标泄漏风险。'
+    : visibleIdentityCheckStatus === 'error'
+      ? identityCheckResult.error || '暗标检查失败，请重新检查。'
+      : visibleIdentityCheckStatus === 'success'
+        ? visibleIdentityFindings.length
+          ? `发现 ${visibleIdentityFindings.length} 个暗标风险。`
+          : '暂未发现明确暗标泄漏。'
+        : hasStaleIdentityCheckResult
+          ? '投标文件或补充词已变化，请重新检查以刷新结果。'
+          : '点击开始检查后展示暗标检查结果。';
 
   function renderDisabledCheckContent(label: string) {
     return (
@@ -1727,7 +2035,112 @@ function RejectionCheckPage() {
     );
   }
 
+  function renderIdentityFindingGroups(findings: IdentityCheckFinding[]) {
+    const groups = groupFindingsByBid(findings);
+    return (
+      <div className="rejection-finding-list">
+        {groups.map((group) => (
+          <section className="rejection-finding-group" key={group.document.id}>
+            {activeResultBidDocumentId === 'all' && (
+              <div className="rejection-finding-group-head">
+                <strong>{getBidDocumentLabel(bidDocuments, group.document.id)}</strong>
+                <span>{group.document.fileName} · {group.findings.length} 个暗标风险</span>
+              </div>
+            )}
+            {group.findings.map((finding) => (
+              <IdentityFindingItem
+                key={finding.id}
+                finding={finding}
+                bidLabel={getBidDocumentLabel(bidDocuments, finding.bidDocumentId)}
+                expanded={identityCheckResult.activeFindingId === finding.id}
+                onToggle={() => toggleIdentityFinding(finding.id)}
+                onDelete={() => deleteIdentityFinding(finding.id)}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
+    );
+  }
+
+  function renderIdentityCheckContent() {
+    if (!checkOptions.identityCheck) {
+      return renderDisabledCheckContent('暗标检查');
+    }
+
+    return (
+      <>
+        <div className="rejection-finding-summary">
+          <div>
+            <span className="section-kicker">暗标检查</span>
+            <h3>{visibleIdentityCheckStatus === 'running' ? '正在检查暗标风险' : '暗标检查结果'}</h3>
+            <p>{identityCheckSummaryText}</p>
+          </div>
+          <div className={`rejection-result-status is-${visibleIdentityCheckStatus}`}>
+            <span>{checkRunStatusLabels[visibleIdentityCheckStatus]}</span>
+            <small>{visibleIdentityCheckStatus === 'success' ? `${visibleIdentityFindings.length} 个暗标风险` : identityCheckResult.progressMessage || '等待执行'}</small>
+          </div>
+        </div>
+        {renderBidResultFilter(visibleIdentityFindings)}
+
+        {visibleIdentityCheckStatus === 'running' ? (
+          <div className="markdown-empty-state rejection-finding-empty">
+            <strong>AI 正在执行三轮暗标检查</strong>
+            <p>{identityCheckResult.progressMessage || '正在分析检查范围、定位原文并补充定稿。'}</p>
+          </div>
+        ) : visibleIdentityCheckStatus === 'error' ? (
+          <div className="markdown-empty-state rejection-finding-empty is-error">
+            <strong>{identityCheckResult.error || '暗标检查失败'}</strong>
+            <p>请确认模型配置可用，或重新检查当前投标文件。</p>
+            <button type="button" className="secondary-action" onClick={() => retrySingleCheck('identity')} disabled={checkRunning || extractionRunning || !bidDocuments.length}>
+              重新检查暗标
+            </button>
+          </div>
+        ) : filterFindingsByActiveBid(visibleIdentityFindings).length ? (
+          renderIdentityFindingGroups(visibleIdentityFindings)
+        ) : (
+          <div className="markdown-empty-state rejection-finding-empty">
+            <strong>{visibleIdentityCheckStatus === 'success' ? '暂未发现暗标风险' : hasStaleIdentityCheckResult ? '检查输入已变化' : '等待暗标检查'}</strong>
+            <p>{identityCheckSummaryText}</p>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  const exportExcel = async () => {
+    if (exportingExcel) return;
+    if (!hasVisibleCheckResult) {
+      showToast('当前没有可导出的检查结果', 'info');
+      return;
+    }
+    setExportingExcel(true);
+    try {
+      const result = await window.yibiao?.rejectionCheck.exportExcel();
+      if (!result || result.canceled) return;
+      showToast(result.message || 'Excel 已导出', 'success');
+      if (result.path) setExportedExcelPath(result.path);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '导出 Excel 失败', 'error');
+    } finally {
+      setExportingExcel(false);
+    }
+  };
+
   const toolbarGroups: FloatingToolbarGroup[] = [
+    {
+      id: 'rejection-check-export',
+      actions: step === 'results' ? [
+        {
+          id: 'export-excel',
+          label: exportingExcel ? '导出中...' : '导出 Excel',
+          variant: 'secondary',
+          disabled: exportingExcel || checkRunning || !hasVisibleCheckResult,
+          tooltip: !hasVisibleCheckResult ? '请先完成至少一项检查' : '导出废标项、错别字、逻辑和暗标检查结果',
+          onClick: () => { void exportExcel(); },
+        },
+      ] : [],
+    },
     {
       id: 'rejection-check-reset',
       actions: [
@@ -1948,16 +2361,24 @@ function RejectionCheckPage() {
           >
             <div className="analysis-result-head rejection-reader-head">
               <div className="rejection-reader-heading">
-                <strong>{activeResultTab === 'analysis' ? '解析结果' : '自定义检查项'}</strong>
+                <strong>{activeResultTab === 'analysis' ? '解析结果' : activeResultTab === 'custom' ? '自定义检查项' : '暗标补充词'}</strong>
                 <span>{activeResultTab === 'analysis'
                   ? `${extractionStatusLabels[visibleExtractionStatus]} · ${resultSourceLabel}`
-                  : customCheckItemsSaving
-                    ? '正在保存自定义检查项'
-                    : extractionRunning || checkRunning
-                      ? '任务运行中暂不能修改自定义检查项，当前检查会使用启动任务时的内容'
-                      : customCheckItemsDirty
-                        ? '内容尚未保存，保存后才用于废标项检查'
-                        : '可填写补充检查口径、人工关注项或项目经验'}</span>
+                  : activeResultTab === 'custom'
+                    ? (customCheckItemsSaving
+                      ? '正在保存自定义检查项'
+                      : extractionRunning || checkRunning
+                        ? '任务运行中暂不能修改自定义检查项，当前检查会使用启动任务时的内容'
+                        : customCheckItemsDirty
+                          ? '内容尚未保存，保存后才用于废标项检查'
+                          : '可填写补充检查口径、人工关注项或项目经验')
+                    : (identityExtraKeywordsSaving
+                      ? '正在保存暗标补充词'
+                      : extractionRunning || checkRunning
+                        ? '任务运行中暂不能修改暗标补充词，当前检查会使用启动任务时的内容'
+                        : identityExtraKeywordsDirty
+                          ? '内容尚未保存，保存后才用于暗标检查'
+                          : '一行一词，只用于暗标检查，不进入废标项检查')}</span>
               </div>
               {activeResultTab === 'custom' && (
                 <div className="rejection-custom-save-actions">
@@ -1971,6 +2392,21 @@ function RejectionCheckPage() {
                     disabled={!customCheckItemsDirty || customCheckItemsDisabled}
                   >
                     {customCheckItemsSaving ? '保存中...' : '保存'}
+                  </button>
+                </div>
+              )}
+              {activeResultTab === 'identity' && (
+                <div className="rejection-custom-save-actions">
+                  <span className={`rejection-custom-save-state${identityExtraKeywordsDirty ? ' is-dirty' : ''}`}>
+                    {identityExtraKeywordsDirty ? '有未保存修改' : '已保存'}
+                  </span>
+                  <button
+                    type="button"
+                    className="primary-action"
+                    onClick={() => void saveIdentityExtraKeywords()}
+                    disabled={!identityExtraKeywordsDirty || identityExtraKeywordsDisabled}
+                  >
+                    {identityExtraKeywordsSaving ? '保存中...' : '保存'}
                   </button>
                 </div>
               )}
@@ -1989,7 +2425,7 @@ function RejectionCheckPage() {
                   <p>{extractionRunning ? '正在提取招标文件中的无效投标、废标项和可能风险。' : '进入本步骤后会自动解析；也可以点击上方“开始解析”。'}</p>
                 </div>
               )
-            ) : (
+            ) : activeResultTab === 'custom' ? (
               <MarkdownEditor
                 className="rejection-custom-editor"
                 value={customCheckItemsDraft}
@@ -1997,6 +2433,24 @@ function RejectionCheckPage() {
                 disabled={customCheckItemsDisabled}
                 placeholder="输入自定义检查项，例如：\n- 关注报价文件是否存在多处不一致\n- 关注资格证明材料有效期是否覆盖投标截止时间\n- 关注技术偏离表是否遗漏关键参数响应"
               />
+            ) : (
+              <div className="rejection-identity-extra-panel">
+                <div className="rejection-identity-checklist">
+                  <strong>内置暗标检查口径</strong>
+                  <ul>
+                    {identityBuiltinChecklist.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+                <MarkdownEditor
+                  className="rejection-custom-editor"
+                  value={identityExtraKeywordsDraft}
+                  onChange={updateIdentityExtraKeywordsDraft}
+                  disabled={identityExtraKeywordsDisabled}
+                  placeholder="一行一词，例如：\n张三\n某某建设\n某某市\n历史业绩项目名"
+                />
+              </div>
             )}
           </section>
         </>
@@ -2040,14 +2494,18 @@ function RejectionCheckPage() {
                   ? 'disabled'
                   : tab.id === 'rejection'
                     ? visibleRejectionCheckStatus
-                    : tab.id === 'typo'
-                      ? visibleTypoCheckStatus
-                      : visibleLogicCheckStatus;
+                  : tab.id === 'typo'
+                    ? visibleTypoCheckStatus
+                    : tab.id === 'logic'
+                      ? visibleLogicCheckStatus
+                      : visibleIdentityCheckStatus;
                 const progressMessage = tab.id === 'rejection'
                   ? rejectionCheckResult.progressMessage
                   : tab.id === 'typo'
                     ? typoCheckResult.progressMessage
-                    : logicCheckResult.progressMessage;
+                    : tab.id === 'logic'
+                      ? logicCheckResult.progressMessage
+                      : identityCheckResult.progressMessage;
                 const progress = getCheckResultTabProgress(status, progressMessage);
                 return (
                   <button
@@ -2113,7 +2571,11 @@ function RejectionCheckPage() {
                     </div>
                   )}
                 </>
-              ) : activeCheckResult.id === 'typo' ? renderTypoCheckContent() : renderLogicCheckContent()}
+              ) : activeCheckResult.id === 'typo'
+                ? renderTypoCheckContent()
+                : activeCheckResult.id === 'logic'
+                  ? renderLogicCheckContent()
+                  : renderIdentityCheckContent()}
             </div>
           </section>
 
@@ -2154,6 +2616,16 @@ function RejectionCheckPage() {
                       onCheckedChange={(checked) => setDraftCheckOptions((prev) => ({ ...prev, logicCheck: checked }))}
                       aria-label="逻辑谬误检查" />
                   </label>
+                  <label className="content-generation-config-row">
+                    <span>
+                      <strong>暗标检查</strong>
+                      <small>检查人名、单位、历史项目、联系方式、地区和英文等可能暴露身份的内容，默认开启。</small>
+                    </span>
+                    <AppSwitch
+                      checked={draftCheckOptions.identityCheck}
+                      onCheckedChange={(checked) => setDraftCheckOptions((prev) => ({ ...prev, identityCheck: checked }))}
+                      aria-label="暗标检查" />
+                  </label>
                 </div>
 
                 <div className="content-regenerate-actions">
@@ -2172,6 +2644,29 @@ function RejectionCheckPage() {
       )}
 
       <FloatingToolbar groups={toolbarGroups} label="废标项检查工具条" />
+      <AppDialog
+        open={Boolean(exportedExcelPath)}
+        onOpenChange={(open) => { if (!open) setExportedExcelPath(''); }}
+        kicker="导出完成"
+        title="是否打开 Excel"
+        description="检查结果已保存到本地，可直接打开核对。"
+        actions={(
+          <>
+            <button type="button" className="secondary-action" onClick={() => setExportedExcelPath('')}>稍后打开</button>
+            <button
+              type="button"
+              className="primary-action"
+              onClick={() => {
+                const filePath = exportedExcelPath;
+                setExportedExcelPath('');
+                if (filePath) void window.yibiao?.export.openFile(filePath);
+              }}
+            >
+              打开文件
+            </button>
+          </>
+        )}
+      />
     </div>
   );
 }

--- a/client/src/features/rejection-check/pages/RejectionCheckPage.tsx
+++ b/client/src/features/rejection-check/pages/RejectionCheckPage.tsx
@@ -1380,15 +1380,14 @@ function RejectionCheckPage() {
       return;
     }
 
-    if (runOptions.rejectionCheck && (visibleExtractionStatus !== 'success' || !visibleExtractionContent.trim())) {
-      showToast('请先完成无效与废标项解析', 'info');
-      setStep('items');
-      return;
-    }
-
-    if (runOptions.rejectionCheck && !currentRejectionCheckInputSignature) {
-      showToast('检查输入不完整，请确认投标文件和检查项', 'info');
-      return;
+    if (runOptions.rejectionCheck && (visibleExtractionStatus !== 'success' || !visibleExtractionContent.trim() || !currentRejectionCheckInputSignature)) {
+      if (!runOptions.typoCheck && !runOptions.logicCheck && !runOptions.identityCheck) {
+        showToast('请先完成无效与废标项解析', 'info');
+        setStep('items');
+        return;
+      }
+      showToast('废标项解析未完成，本次只检查已启用的其他项', 'info');
+      runOptions = { ...runOptions, rejectionCheck: false };
     }
 
     if (!runOptions.rejectionCheck && !runOptions.typoCheck && !runOptions.logicCheck && !runOptions.identityCheck) {
@@ -1765,7 +1764,13 @@ function RejectionCheckPage() {
     : hasVisibleCheckResult
       ? '重新检查'
       : '开始检查';
-  const rejectionCheckSummaryText = visibleRejectionCheckStatus === 'running'
+  const rejectionExtractionReady = visibleExtractionStatus === 'success' && Boolean(currentRejectionCheckInputSignature);
+  const canStartOtherChecks = draftCheckOptions.typoCheck || draftCheckOptions.logicCheck || draftCheckOptions.identityCheck;
+  const startCheckDisabled = checkRunning || extractionRunning || !bidDocuments.length || (!rejectionExtractionReady && !canStartOtherChecks);
+  const rejectionCheckNeedsExtraction = visibleExtractionStatus !== 'success';
+  const rejectionCheckSummaryText = rejectionCheckNeedsExtraction
+    ? '需先完成废标项解析'
+    : visibleRejectionCheckStatus === 'running'
     ? rejectionCheckResult.progressMessage || 'AI 正在检查投标文件。'
     : visibleRejectionCheckStatus === 'error'
       ? rejectionCheckResult.error || '废标项检查失败，请重新检查。'
@@ -2566,8 +2571,8 @@ function RejectionCheckPage() {
                     renderRejectionFindingGroups(visibleRejectionFindings)
                   ) : (
                     <div className="markdown-empty-state rejection-finding-empty">
-                      <strong>{visibleRejectionCheckStatus === 'success' ? '暂未发现废标项风险' : hasStaleRejectionCheckResult ? '检查输入已变化' : '等待废标项检查'}</strong>
-                      <p>{rejectionCheckSummaryText}</p>
+                      <strong>{visibleRejectionCheckStatus === 'success' ? '暂未发现废标项风险' : rejectionCheckNeedsExtraction ? '需先完成废标项解析' : hasStaleRejectionCheckResult ? '检查输入已变化' : '等待废标项检查'}</strong>
+                      <p>{rejectionCheckNeedsExtraction ? '废标项解析未完成时，仍可检查已启用的暗标、错别字和逻辑项。' : rejectionCheckSummaryText}</p>
                     </div>
                   )}
                 </>
@@ -2633,7 +2638,7 @@ function RejectionCheckPage() {
                   <button type="button" className="secondary-action" onClick={saveCheckOptions}>
                     保存配置
                   </button>
-                  <button type="button" className="primary-action" onClick={startCheckWithOptions} disabled={checkRunning || extractionRunning || !bidDocuments.length || (draftCheckOptions.rejectionCheck && (visibleExtractionStatus !== 'success' || !currentRejectionCheckInputSignature))}>
+                  <button type="button" className="primary-action" onClick={startCheckWithOptions} disabled={startCheckDisabled}>
                     {checkActionLabel}
                   </button>
                 </div>

--- a/client/src/features/rejection-check/types.ts
+++ b/client/src/features/rejection-check/types.ts
@@ -6,9 +6,19 @@ export type RejectionDocumentSource = 'upload' | 'technical-plan';
 
 export type RejectionCheckStep = 'documents' | 'items' | 'results';
 
-export type RejectionResultTab = 'analysis' | 'custom';
+export type RejectionResultTab = 'analysis' | 'custom' | 'identity';
 
-export type RejectionCheckResultTab = 'rejection' | 'typo' | 'logic';
+export type RejectionCheckResultTab = 'rejection' | 'typo' | 'logic' | 'identity';
+
+export type IdentityCheckCategory =
+  | 'person'
+  | 'org'
+  | 'project'
+  | 'contact'
+  | 'region'
+  | 'english'
+  | 'punctuation'
+  | 'custom';
 
 export type RejectionExtractionStatus = 'idle' | 'running' | 'success' | 'error';
 
@@ -55,25 +65,29 @@ export interface RejectionCheckWorkspaceState {
   activeCheckResultTab?: RejectionCheckResultTab;
   invalidBidAndRejectionItems?: RejectionExtractionState;
   customCheckItems?: string;
+  identityExtraKeywords?: string;
   checkOptions?: RejectionCheckOptions;
   rejectionCheckResult?: RejectionCheckResultState;
   typoCheckResult?: TypoCheckResultState;
   logicCheckResult?: LogicCheckResultState;
+  identityCheckResult?: IdentityCheckResultState;
   extractionTask?: RejectionBackgroundTaskState;
   checkTask?: RejectionBackgroundTaskState;
 }
 
 export type RejectionCheckWorkspacePatch = Omit<Partial<RejectionCheckWorkspaceState>,
-  'rejectionCheckResult' | 'typoCheckResult' | 'logicCheckResult'> & {
+  'rejectionCheckResult' | 'typoCheckResult' | 'logicCheckResult' | 'identityCheckResult'> & {
   rejectionCheckResult?: Partial<RejectionCheckResultState>;
   typoCheckResult?: Partial<TypoCheckResultState>;
   logicCheckResult?: Partial<LogicCheckResultState>;
+  identityCheckResult?: Partial<IdentityCheckResultState>;
 };
 
 export interface RejectionCheckOptions {
   rejectionCheck: boolean;
   typoCheck: boolean;
   logicCheck: boolean;
+  identityCheck: boolean;
 }
 
 export interface RejectionExtractionState {
@@ -141,6 +155,27 @@ export interface LogicCheckFinding {
 export interface LogicCheckResultState {
   status: RejectionCheckRunStatus;
   findings: LogicCheckFinding[];
+  inputSignature?: string;
+  activeFindingId?: string;
+  progressMessage?: string;
+  updatedAt?: string;
+  error?: string;
+}
+
+export interface IdentityCheckFinding {
+  id: string;
+  bidDocumentId: string;
+  category: IdentityCheckCategory;
+  matchedText: string;
+  originalExcerpt: string;
+  locationHint: string;
+  riskReason: string;
+  suggestion: string;
+}
+
+export interface IdentityCheckResultState {
+  status: RejectionCheckRunStatus;
+  findings: IdentityCheckFinding[];
   inputSignature?: string;
   activeFindingId?: string;
   progressMessage?: string;

--- a/client/src/features/settings/pages/SettingsPage.tsx
+++ b/client/src/features/settings/pages/SettingsPage.tsx
@@ -144,9 +144,21 @@ function parseTextTemperatureInput(value: string): number {
   return normalizeTextTemperature(value);
 }
 
+function allowsEditableBaseUrl(provider: string): boolean {
+  return provider === 'custom' || provider === 'volcengine';
+}
+
+function resolvePersistedBaseUrl(provider: string, profileBaseUrl?: string, defaultBaseUrl = ''): string {
+  return allowsEditableBaseUrl(provider) ? profileBaseUrl ?? defaultBaseUrl : defaultBaseUrl;
+}
+
+function getVolcengineBaseUrlHint() {
+  return '火山方舟订阅套餐请填 https://ark.cn-beijing.volces.com/api/plan/v3；后付费才是 /api/v3。';
+}
+
 function normalizeTextModelProfile(provider: ConfiguredTextModelProvider, profile?: Partial<TextModelConfig>): TextModelConfig {
   const defaults = textProviderDefaults[provider];
-  const baseUrl = provider === 'custom' ? profile?.base_url ?? defaults.base_url : defaults.base_url;
+  const baseUrl = resolvePersistedBaseUrl(provider, profile?.base_url, defaults.base_url);
   return {
     api_key: profile?.api_key ?? defaults.api_key,
     base_url: baseUrl,
@@ -179,7 +191,7 @@ function normalizeTextModelProfiles(
 function textProfileFromState(textModel: SettingsPageState['textModel']): TextModelConfig {
   return {
     api_key: textModel.api_key,
-    base_url: textModel.provider === 'custom' ? textModel.base_url : textProviderDefaults[textModel.provider].base_url,
+    base_url: resolvePersistedBaseUrl(textModel.provider, textModel.base_url, textProviderDefaults[textModel.provider].base_url),
     model_name: textModel.model_name,
     reasoning_effort: textModel.reasoning_effort.trim(),
     context_length_limit: normalizeTextContextLengthLimit(textModel.context_length_limit),
@@ -311,7 +323,7 @@ const imageProviderLabels: Record<ImageModelProvider, string> = {
 
 function getImageBaseUrlDescription(provider: ImageModelProvider) {
   if (provider === 'jinlong') return '金龙中转站 OpenAI 兼容接口地址';
-  if (provider === 'volcengine') return '火山方舟 OpenAI 兼容接口地址';
+  if (provider === 'volcengine') return `火山方舟 OpenAI 兼容接口地址。${getVolcengineBaseUrlHint()}`;
   if (provider === 'agnes') return 'Agnes AI OpenAI 兼容接口地址';
   if (provider === 'custom') return '填写兼容 OpenAI /images/generations 的接口地址';
   return 'Google Gemini API REST 地址';
@@ -353,7 +365,7 @@ function normalizeImageModelProfile(provider: ImageModelProvider, profile?: Part
   const useProviderDefaultImageModel = provider === 'jinlong' && !String(profile?.model_name ?? '').trim();
   return {
     provider,
-    base_url: provider === 'custom' ? profile?.base_url ?? defaults.base_url : defaults.base_url,
+    base_url: resolvePersistedBaseUrl(provider, profile?.base_url, defaults.base_url),
     api_key: profile?.api_key ?? defaults.api_key,
     model_name: useProviderDefaultImageModel ? defaults.model_name : profile?.model_name ?? defaults.model_name,
     image_size: normalizeImageSize(provider, useProviderDefaultImageModel ? defaults.image_size : profile?.image_size ?? defaults.image_size),
@@ -429,7 +441,11 @@ function normalizeImageModelProfiles(profiles?: Partial<ImageModelProfiles>): Im
 function imageProfileFromState(imageModel: SettingsPageState['imageModel']): ImageModelConfig {
   return {
     provider: imageModel.provider,
-    base_url: imageModel.provider === 'custom' ? imageModel.base_url || '' : imageProviderDefaults[imageModel.provider].base_url,
+    base_url: resolvePersistedBaseUrl(
+      imageModel.provider,
+      imageModel.base_url || '',
+      imageProviderDefaults[imageModel.provider].base_url,
+    ),
     api_key: imageModel.api_key,
     model_name: imageModel.model_name,
     image_size: normalizeImageSize(imageModel.provider, imageModel.image_size),
@@ -1687,7 +1703,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
             <label className="settings-row">
               <div className="settings-row-copy">
                 <strong>服务提供商</strong>
-                <span>选择服务商会自动使用预置 Base URL；只有自定义服务商允许修改</span>
+                <span>选择服务商会自动填入预置 Base URL。火山方舟和自定义允许修改。{getVolcengineBaseUrlHint()}</span>
               </div>
               <select
                 value={state.textModel.provider}
@@ -1704,14 +1720,14 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
             <label className="settings-row">
               <div className="settings-row-copy">
                 <strong>Base URL</strong>
-                <span>OpenAI Like 接口地址，用于文本生成和分析任务</span>
+                <span>{state.textModel.provider === 'volcengine' ? getVolcengineBaseUrlHint() : 'OpenAI Like 接口地址，用于文本生成和分析任务'}</span>
               </div>
               <input
                 type="text"
                 value={state.textModel.base_url}
                 placeholder={currentTextProviderDefault.base_url || '例如 https://api.openai.com/v1'}
                 onChange={(event) => updateTextModelConfig({ base_url: event.target.value }, { clearModels: true })}
-                disabled={state.textModel.provider !== 'custom'}
+                disabled={!allowsEditableBaseUrl(state.textModel.provider)}
               />
             </label>
             <label className="settings-row">
@@ -1921,7 +1937,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                 value={state.imageModel.base_url || ''}
                 placeholder={state.imageModel.provider === 'custom' ? 'https://api.example.com/v1' : imageProviderDefaults[state.imageModel.provider].base_url}
                 onChange={(event) => updateImageModelConfig({ base_url: event.target.value }, { clearModels: true })}
-                disabled={state.imageModel.provider !== 'custom'}
+                disabled={!allowsEditableBaseUrl(state.imageModel.provider)}
               />
             </label>
             <label className="settings-row">

--- a/client/src/features/technical-plan/pages/BidAnalysisPage.tsx
+++ b/client/src/features/technical-plan/pages/BidAnalysisPage.tsx
@@ -1,8 +1,8 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useEffect, useMemo, useState } from 'react';
 import { trackConfigUsage } from '../../../shared/analytics/analytics';
-import { bidAnalysisTasks, getBidAnalysisTasks } from '../services/bidAnalysisWorkflow';
-import { MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, useToast } from '../../../shared/ui';
+import { bidAnalysisTasks, getBidAnalysisTasks, isSelectableBidAnalysisTask } from '../services/bidAnalysisWorkflow';
+import { AppDialog, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, useToast } from '../../../shared/ui';
 import BidSectionSelectorDialog from '../components/BidSectionSelectorDialog';
 import type { BackgroundTaskState, BidAnalysisMode, BidAnalysisTasks, BidAnalysisTaskState, BidSectionExtractionStatus, BidSectionMode, DetectedBidSection, TechnicalPlanState } from '../types';
 
@@ -36,7 +36,9 @@ const modeOptions: Array<{ id: 'key' | 'full'; title: string; badge: string }> =
   },
 ];
 
-const allBidAnalysisTaskIds = bidAnalysisTasks.map((task) => task.id);
+const selectableBidAnalysisTasks = bidAnalysisTasks.filter(isSelectableBidAnalysisTask);
+const allBidAnalysisTaskIds = selectableBidAnalysisTasks.map((task) => task.id);
+const briefingTaskDefinition = bidAnalysisTasks.find((task) => task.id === 'bidBriefing');
 const requiredBidAnalysisTaskIds = getBidAnalysisTasks('key').map((task) => task.id);
 const requiredBidAnalysisTaskIdSet = new Set(requiredBidAnalysisTaskIds);
 
@@ -173,7 +175,7 @@ function JsonResultTable({ content }: { content: string }) {
   if (!data) {
     return (
       <MarkdownFullscreenViewer className="markdown-viewer bid-analysis-output" title="JSON 内容全屏预览">
-        <MarkdownRenderer>
+        <MarkdownRenderer allowRawHtml={false}>
           {`\`\`\`json\n${content}\n\`\`\``}
         </MarkdownRenderer>
       </MarkdownFullscreenViewer>
@@ -194,6 +196,37 @@ function JsonResultTable({ content }: { content: string }) {
       </table>
     </div>
   );
+}
+
+const briefingSourceIds = ['projectOverview', 'projectInfo', 'partAInfo', 'responseFileRequirements', 'techRequirements', 'businessScoring', 'discardedBids', 'keyInfo', 'marginInfo'] as const;
+const requiredBriefingSourceIds = ['projectOverview', 'projectInfo', 'partAInfo', 'responseFileRequirements'] as const;
+
+function summarizeText(content: string, limit = 280) {
+  const text = String(content || '').replace(/\s+/g, ' ').trim();
+  if (!text) return '尚未解析';
+  return text.length > limit ? `${text.slice(0, limit)}…` : text;
+}
+
+function formatBriefingJson(content: string) {
+  const data = tryParseJsonObject(content);
+  if (!data) return summarizeText(content);
+  return Object.entries(data)
+    .map(([key, value]) => `${jsonFieldLabels[key] || key}：${formatJsonValue(value)}`)
+    .join('；');
+}
+
+function buildInstantBriefingMarkdown(tasks: BidAnalysisTasks) {
+  const item = (id: string) => tasks[id];
+  const success = (id: string) => item(id)?.status === 'success' && String(item(id)?.content || '').trim();
+  const sections = [
+    { title: '项目是什么', body: [success('projectOverview') ? String(item('projectOverview')?.content) : '', success('projectInfo') ? formatBriefingJson(String(item('projectInfo')?.content)) : ''].filter(Boolean).join('\n\n') || '关键项尚未完成，项目信息还不完整。' },
+    { title: '谁采购', body: success('partAInfo') ? formatBriefingJson(String(item('partAInfo')?.content)) : '尚未解析甲方信息。' },
+    { title: '必须响应', body: success('responseFileRequirements') ? summarizeText(String(item('responseFileRequirements')?.content), 500) : '尚未解析响应文件要求。' },
+    { title: '评分重点', body: [success('techRequirements') ? summarizeText(String(item('techRequirements')?.content), 360) : '', success('businessScoring') ? summarizeText(String(item('businessScoring')?.content), 240) : ''].filter(Boolean).join('\n\n') || '尚未解析评分项。' },
+    { title: '废标点', body: success('discardedBids') ? summarizeText(String(item('discardedBids')?.content), 360) : '尚未解析废标项。' },
+    { title: '节点', body: [success('keyInfo') ? formatBriefingJson(String(item('keyInfo')?.content)) : '', success('marginInfo') ? formatBriefingJson(String(item('marginInfo')?.content)) : ''].filter(Boolean).join('\n\n') || '尚未解析关键节点或保证金。' },
+  ];
+  return sections.map((section) => `### ${section.title}\n${section.body}`).join('\n\n');
 }
 
 function BidAnalysisPage({
@@ -228,17 +261,29 @@ function BidAnalysisPage({
     nextTaskIds: string[];
   } | null>(null);
   const [progressCollapsed, setProgressCollapsed] = useState(false);
+  const [exportedBriefingPath, setExportedBriefingPath] = useState('');
   const { showToast } = useToast();
   const effectiveSelectedTaskIds = useMemo(() => getSelectedTaskIdsForMode(mode, selectedTaskIds), [mode, selectedTaskIds]);
   const selectedTasks = useMemo(() => {
     const selectedIdSet = new Set(effectiveSelectedTaskIds);
-    return bidAnalysisTasks.filter((task) => selectedIdSet.has(task.id));
+    return selectableBidAnalysisTasks.filter((task) => selectedIdSet.has(task.id));
   }, [effectiveSelectedTaskIds]);
   const requiredTasks = useMemo(() => getBidAnalysisTasks('key'), []);
-  const visibleSelectedTaskId = selectedTasks.some((task) => task.id === selectedTaskId)
-    ? selectedTaskId
-    : selectedTasks[0]?.id || 'projectOverview';
-  const activeTask = selectedTasks.find((task) => task.id === visibleSelectedTaskId) || selectedTasks[0];
+  const instantBriefingMarkdown = useMemo(() => buildInstantBriefingMarkdown(tasks), [tasks]);
+  const briefingState = tasks.bidBriefing;
+  const briefingContent = briefingState?.content || '';
+  const briefingIncomplete = requiredBriefingSourceIds.some((id) => tasks[id]?.status !== 'success' || !String(tasks[id]?.content || '').trim())
+    || briefingSourceIds.some((id) => !tasks[id]?.content);
+  const exportableBriefing = briefingContent.trim() || instantBriefingMarkdown;
+  const briefingSelected = selectedTaskId === 'bidBriefing';
+  const visibleSelectedTaskId = briefingSelected
+    ? 'bidBriefing'
+    : selectedTasks.some((task) => task.id === selectedTaskId)
+      ? selectedTaskId
+      : selectedTasks[0]?.id || 'projectOverview';
+  const activeTask = briefingSelected
+    ? briefingTaskDefinition
+    : selectedTasks.find((task) => task.id === visibleSelectedTaskId) || selectedTasks[0];
   const activeTaskState = activeTask ? tasks[activeTask.id] : undefined;
   const activeTaskStatus = activeTaskState?.status || 'idle';
   const activeTaskContent = activeTaskState?.content || '';
@@ -267,7 +312,7 @@ function BidAnalysisPage({
 
   const syncProgressForSelection = (nextTaskIds: string[]) => {
     const selectedIdSet = new Set(normalizeSelectedTaskIds(nextTaskIds));
-    const nextTasks = bidAnalysisTasks.filter((task) => selectedIdSet.has(task.id));
+    const nextTasks = selectableBidAnalysisTasks.filter((task) => selectedIdSet.has(task.id));
     const nextDoneCount = nextTasks.filter((task) => {
       const status = tasks[task.id]?.status;
       return status === 'success' || status === 'error';
@@ -349,7 +394,7 @@ function BidAnalysisPage({
 
     const normalizedTaskIds = normalizeSelectedTaskIds(nextTaskIds);
     const nextSelectedIdSet = new Set(normalizedTaskIds);
-    const nextSelectedTasks = bidAnalysisTasks.filter((task) => nextSelectedIdSet.has(task.id));
+    const nextSelectedTasks = selectableBidAnalysisTasks.filter((task) => nextSelectedIdSet.has(task.id));
     const retryTask = taskIds?.length === 1 ? nextSelectedTasks.find((task) => task.id === taskIds[0]) : undefined;
     const forceRerun = !taskIds?.length && nextSelectedTasks.length > 0 && nextSelectedTasks.every((task) => tasks[task.id]?.status === 'success');
 
@@ -524,6 +569,59 @@ function BidAnalysisPage({
     }
   };
 
+  const startBriefing = async () => {
+    if (!hasTenderFile) {
+      showToast('请先上传招标文件', 'info');
+      return;
+    }
+    try {
+      setRunning(true);
+      await window.yibiao?.tasks.startBidAnalysis({
+        mode,
+        selected_task_ids: effectiveSelectedTaskIds,
+        task_ids: ['bidBriefing'],
+      });
+      setSelectedTaskId('bidBriefing');
+      showToast('项目简报生成任务已在后台启动', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '启动简报任务失败', 'error');
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  const copyBriefing = async () => {
+    if (!exportableBriefing.trim()) {
+      showToast('当前没有可复制的简报', 'info');
+      return;
+    }
+    await navigator.clipboard.writeText(briefingContent.trim() || instantBriefingMarkdown);
+    showToast('简报已复制', 'success');
+  };
+
+  const exportBriefing = async () => {
+    if (!exportableBriefing.trim()) {
+      showToast('当前没有可导出的简报', 'info');
+      return;
+    }
+    try {
+      const result = await window.yibiao?.technicalPlan.exportMarkdown({
+        content: briefingContent.trim() || instantBriefingMarkdown,
+        defaultFileName: '项目简报.md',
+        title: '导出项目简报',
+      });
+      if (result?.canceled) return;
+      if (!result?.success) {
+        showToast(result?.message || '导出简报失败', 'error');
+        return;
+      }
+      showToast(result.message || 'Markdown 已导出', 'success');
+      if (result.path) setExportedBriefingPath(result.path);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '导出简报失败', 'error');
+    }
+  };
+
   const copyActiveResult = async () => {
     if (!activeTaskContent) {
       showToast('当前没有可复制的解析结果', 'info');
@@ -615,6 +713,18 @@ function BidAnalysisPage({
             )}
           </div>
           <div className="bid-analysis-task-list">
+            <div className="bid-analysis-task-group">
+              <span>项目简报</span>
+              <button
+                type="button"
+                className={`bid-analysis-task-item is-${briefingState?.status || 'idle'}${briefingSelected ? ' is-active' : ''}`}
+                onClick={() => setSelectedTaskId('bidBriefing')}
+              >
+                <strong>项目简报</strong>
+                <small>{briefingContent ? `${briefingContent.length} 字` : '从已解析项拼一页，也可再生成 AI 简报'}</small>
+                <em>{statusLabel[briefingState?.status || 'idle']}</em>
+              </button>
+            </div>
             {taskGroups.map((group) => {
               const groupTasks = selectedTasks.filter((task) => group.ids.includes(task.id));
               if (!groupTasks.length) {
@@ -648,36 +758,76 @@ function BidAnalysisPage({
         </aside>
 
         <article className="bid-analysis-reader">
-          <div className="bid-analysis-reader-head">
-            <div>
-              <span className="section-kicker">解析结果</span>
-              <strong>{activeTask?.label || '解析结果'}</strong>
-              <p>{activeTask?.description || '选择左侧任务查看解析结果。'}</p>
-            </div>
-            <div className="bid-analysis-reader-actions">
-              <span className={`bid-analysis-status is-${activeTaskStatus}`}>{statusLabel[activeTaskStatus]}</span>
-              {activeTaskStatus === 'error' && (
-                <button type="button" className="secondary-action" onClick={retryActiveTask} disabled={taskRunning || !hasTenderFile}>重新解析此项</button>
-              )}
-              <button type="button" className="secondary-action" onClick={copyActiveResult} disabled={!activeTaskContent}>复制</button>
-            </div>
-          </div>
-
-          {activeTaskContent ? (
-            activeTask?.output === 'json' ? (
-              <JsonResultTable content={activeTaskContent} />
-            ) : (
-              <MarkdownFullscreenViewer className="markdown-viewer bid-analysis-output" title={`${activeTask?.label || '解析结果'}全屏预览`}>
-                <MarkdownRenderer>
-                  {activeTaskContent}
-                </MarkdownRenderer>
-              </MarkdownFullscreenViewer>
-            )
+          {briefingSelected ? (
+            <>
+              <div className="bid-analysis-reader-head">
+                <div>
+                  <span className="section-kicker">项目简报</span>
+                  <strong>一页纸要点</strong>
+                  <p>先用已解析项拼出即时卡片，再按需生成 AI 简报。AI 简报不进入默认关键项。</p>
+                </div>
+                <div className="bid-analysis-reader-actions">
+                  <span className={`bid-analysis-status is-${briefingState?.status || 'idle'}`}>{statusLabel[briefingState?.status || 'idle']}</span>
+                  <button type="button" className="secondary-action" onClick={() => void copyBriefing()} disabled={!exportableBriefing.trim()}>复制简报</button>
+                  <button type="button" className="secondary-action" onClick={() => void exportBriefing()} disabled={!exportableBriefing.trim()}>导出 Markdown</button>
+                  <button type="button" className="primary-action" onClick={() => void startBriefing()} disabled={taskRunning || !hasTenderFile}>
+                    {briefingState?.status === 'running' ? '生成中...' : briefingContent ? '重新生成简报' : '生成简报'}
+                  </button>
+                </div>
+              </div>
+              <div className="bid-briefing-body">
+                {briefingIncomplete && (
+                  <p className="bid-briefing-incomplete">关键项尚未全部完成，当前简报不完整，仅展示已有字段。</p>
+                )}
+                <div className="bid-briefing-card">
+                  <MarkdownRenderer allowRawHtml={false}>{instantBriefingMarkdown}</MarkdownRenderer>
+                </div>
+                {briefingContent ? (
+                  <MarkdownFullscreenViewer className="markdown-viewer bid-analysis-output" title="项目简报全屏预览">
+                    <MarkdownRenderer allowRawHtml={false}>{briefingContent}</MarkdownRenderer>
+                  </MarkdownFullscreenViewer>
+                ) : (
+                  <div className="markdown-empty-state bid-analysis-empty">
+                    <strong>{briefingState?.status === 'error' ? briefingState.error || '简报生成失败' : '还没有 AI 简报'}</strong>
+                    <p>即时卡片已根据已解析项生成。点击“生成简报”后，会把已成功项交给模型整理成一页 Markdown。</p>
+                  </div>
+                )}
+              </div>
+            </>
           ) : (
-            <div className="markdown-empty-state bid-analysis-empty">
-              <strong>{activeTaskStatus === 'error' ? activeTaskState?.error || '解析失败' : '等待解析结果'}</strong>
-              <p>{activeTaskStatus === 'idle' ? '点击开始解析后，左侧任务会并发运行；选择任一任务查看实时输出。' : '正在等待模型返回内容。'}</p>
-            </div>
+            <>
+              <div className="bid-analysis-reader-head">
+                <div>
+                  <span className="section-kicker">解析结果</span>
+                  <strong>{activeTask?.label || '解析结果'}</strong>
+                  <p>{activeTask?.description || '选择左侧任务查看解析结果。'}</p>
+                </div>
+                <div className="bid-analysis-reader-actions">
+                  <span className={`bid-analysis-status is-${activeTaskStatus}`}>{statusLabel[activeTaskStatus]}</span>
+                  {activeTaskStatus === 'error' && (
+                    <button type="button" className="secondary-action" onClick={retryActiveTask} disabled={taskRunning || !hasTenderFile}>重新解析此项</button>
+                  )}
+                  <button type="button" className="secondary-action" onClick={copyActiveResult} disabled={!activeTaskContent}>复制</button>
+                </div>
+              </div>
+
+              {activeTaskContent ? (
+                activeTask?.output === 'json' ? (
+                  <JsonResultTable content={activeTaskContent} />
+                ) : (
+                  <MarkdownFullscreenViewer className="markdown-viewer bid-analysis-output" title={`${activeTask?.label || '解析结果'}全屏预览`}>
+                    <MarkdownRenderer allowRawHtml={false}>
+                      {activeTaskContent}
+                    </MarkdownRenderer>
+                  </MarkdownFullscreenViewer>
+                )
+              ) : (
+                <div className="markdown-empty-state bid-analysis-empty">
+                  <strong>{activeTaskStatus === 'error' ? activeTaskState?.error || '解析失败' : '等待解析结果'}</strong>
+                  <p>{activeTaskStatus === 'idle' ? '点击开始解析后，左侧任务会并发运行；选择任一任务查看实时输出。' : '正在等待模型返回内容。'}</p>
+                </div>
+              )}
+            </>
           )}
         </article>
       </section>
@@ -775,7 +925,7 @@ function BidAnalysisPage({
                   <span>{requiredBidAnalysisTaskIds.length} 项必选</span>
                 </div>
                 <div className="bid-analysis-config-grid">
-                  {bidAnalysisTasks.filter((definition) => definition.required).map(renderConfigTask)}
+                  {selectableBidAnalysisTasks.filter((definition) => definition.required).map(renderConfigTask)}
                 </div>
               </section>
 
@@ -785,7 +935,7 @@ function BidAnalysisPage({
                   <span>当前共选择 {draftSelectedCount} 项</span>
                 </div>
                 <div className="bid-analysis-config-grid">
-                  {bidAnalysisTasks.filter((definition) => !definition.required).map(renderConfigTask)}
+                  {selectableBidAnalysisTasks.filter((definition) => !definition.required).map(renderConfigTask)}
                 </div>
               </section>
             </div>
@@ -848,6 +998,32 @@ function BidAnalysisPage({
         onSelect={handleSectionSelect}
         onCancel={handleSectionCancel}
         busy={selectingSection}
+      />
+
+      <AppDialog
+        open={Boolean(exportedBriefingPath)}
+        onOpenChange={(open) => { if (!open) setExportedBriefingPath(''); }}
+        kicker="导出完成"
+        title="是否打开简报文件？"
+        description={exportedBriefingPath}
+        actions={(
+          <>
+            <button type="button" className="secondary-action" onClick={() => setExportedBriefingPath('')}>稍后打开</button>
+            <button
+              type="button"
+              className="primary-action"
+              onClick={() => {
+                const filePath = exportedBriefingPath;
+                setExportedBriefingPath('');
+                void window.yibiao?.export.openFile(filePath).catch((error) => {
+                  showToast(error instanceof Error ? error.message : '打开文件失败', 'error');
+                });
+              }}
+            >
+              打开文件
+            </button>
+          </>
+        )}
       />
     </div>
   );

--- a/client/src/features/technical-plan/pages/ContentEditPage.tsx
+++ b/client/src/features/technical-plan/pages/ContentEditPage.tsx
@@ -23,6 +23,8 @@ interface ContentEditPageProps {
   contentGenerationOptions?: ContentGenerationOptions;
   contentIllustrationPlan?: ContentIllustrationPlanState;
   sections: ContentGenerationSections;
+  templateFillTask?: BackgroundTaskState;
+  pointToPointTask?: BackgroundTaskState;
   onContentGenerationOptionsChange: (options: ContentGenerationOptions) => Promise<void> | void;
   onContentSaved: (item: OutlineItem, content: string) => Promise<void> | void;
 }
@@ -49,8 +51,8 @@ const statusLabels: Record<TreeStatus, string> = {
 };
 
 const pendingModeDescriptions: Record<Exclude<OutlineContentMode, 'ai-generate'>, string> = {
-  'template-fill': '该小节已标记为模板填写，后续将从招标文件提取并填充内容。',
-  'point-to-point': '该小节已标记为点对点应答表，后续将在正文完成并确定 Word 页码后回填。',
+  'template-fill': '该小节已标记为模板填写，可从招标原文提取表格或格式后回填。没有依据的格子会保留【待填写】。',
+  'point-to-point': '该小节已标记为点对点应答表。建议在正文完成后生成，页码会写成 Word 域占位，打开文档后更新域即可出页码。',
   other: '该小节采用其他处理模式，暂不进入 AI 正文生成流程。',
 };
 
@@ -276,6 +278,7 @@ function buildOutlineMeta(items: OutlineItem[], sections: ContentGenerationSecti
 const MarkdownContent = memo(function MarkdownContent({ content, onPreviewImage }: { content: string; onPreviewImage: (src: string, alt: string) => void }) {
   return (
     <MarkdownRenderer
+      allowRawHtml={false}
       imageMode="preview"
       imageClassName="markdown-clickable-image"
       renderMermaid
@@ -294,6 +297,8 @@ function ContentEditPage({
   contentGenerationOptions,
   contentIllustrationPlan,
   sections,
+  templateFillTask,
+  pointToPointTask,
   onContentGenerationOptionsChange,
   onContentSaved,
 }: ContentEditPageProps) {
@@ -328,7 +333,10 @@ function ContentEditPage({
   const pausing = task?.status === 'pausing' || pausePending;
   const paused = task?.status === 'paused';
   const taskFailed = task?.status === 'error';
-  const taskInFlight = running || pausing;
+  const templateFillRunning = templateFillTask?.status === 'running' || templateFillTask?.status === 'pausing';
+  const pointToPointRunning = pointToPointTask?.status === 'running' || pointToPointTask?.status === 'pausing';
+  const chapterModeTaskRunning = templateFillRunning || pointToPointRunning;
+  const taskInFlight = running || pausing || chapterModeTaskRunning;
   const phaseVisible = taskInFlight || paused || taskFailed;
   const taskBlocksGeneration = taskInFlight || paused;
   const contentStats = task?.stats?.content;
@@ -373,6 +381,8 @@ function ContentEditPage({
       totalWords: summary.totalWords + (status === 'ignored' ? 0 : (outlineMeta.get(item.id)?.words || 0)),
     };
   }, { completedCount: 0, failedCount: 0, ignoredCount: 0, totalWords: 0 }), [leaves, outlineMeta, sections]);
+  const templateFillLeaves = useMemo(() => allLeaves.filter((item) => item.content_mode === 'template-fill'), [allLeaves]);
+  const pointToPointLeaves = useMemo(() => allLeaves.filter((item) => item.content_mode === 'point-to-point'), [allLeaves]);
   const { completedCount, failedCount, ignoredCount, totalWords } = contentSummary;
   const resolvedCount = completedCount + ignoredCount;
   const unresolvedCount = Math.max(0, leaves.length - resolvedCount);
@@ -972,6 +982,30 @@ function ContentEditPage({
     }
   };
 
+  const startChapterModeTask = async (mode: 'template-fill' | 'point-to-point', nodeIds?: string[]) => {
+    if (taskBlocksGeneration) {
+      showToast('请先完成当前正文或模板任务，再继续', 'info');
+      return;
+    }
+    const targets = mode === 'template-fill' ? templateFillLeaves : pointToPointLeaves;
+    const selectedIds = nodeIds?.length ? nodeIds : targets.map((item) => item.id);
+    if (!selectedIds.length) {
+      showToast(mode === 'template-fill' ? '当前没有模板填写小节' : '当前没有点对点应答表小节', 'info');
+      return;
+    }
+    try {
+      if (mode === 'template-fill') {
+        await window.yibiao?.tasks.startTemplateFill({ nodeIds: selectedIds });
+        showToast(selectedIds.length === 1 ? '模板填写任务已在后台启动' : `已开始填充 ${selectedIds.length} 个模板小节`, 'success');
+      } else {
+        await window.yibiao?.tasks.startPointToPoint({ nodeIds: selectedIds });
+        showToast(selectedIds.length === 1 ? '点对点应答表任务已在后台启动' : `已开始生成 ${selectedIds.length} 个应答表`, 'success');
+      }
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '启动任务失败', 'error');
+    }
+  };
+
   const renderTree = (items: OutlineItem[], level = 0): ReactNode => items.map((item) => {
     const meta = outlineMeta.get(item.id);
     const status = meta?.status || 'idle';
@@ -1075,6 +1109,16 @@ function ContentEditPage({
               <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.05.05a2 2 0 0 1-2.83 2.83l-.05-.05a1.7 1.7 0 0 0-1.87-.34 1.7 1.7 0 0 0-1.04 1.56V21a2 2 0 0 1-4 0v-.08a1.7 1.7 0 0 0-1.04-1.56 1.7 1.7 0 0 0-1.87.34l-.05.05a2 2 0 0 1-2.83-2.83l.05-.05A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-1.56-1.04H3a2 2 0 0 1 0-4h.08A1.7 1.7 0 0 0 4.6 8.93a1.7 1.7 0 0 0-.34-1.87l-.05-.05a2 2 0 0 1 2.83-2.83l.05.05a1.7 1.7 0 0 0 1.87.34A1.7 1.7 0 0 0 10 3.01V3a2 2 0 0 1 4 0v.08a1.7 1.7 0 0 0 1.04 1.56 1.7 1.7 0 0 0 1.87-.34l.05-.05a2 2 0 0 1 2.83 2.83l-.05.05a1.7 1.7 0 0 0-.34 1.87 1.7 1.7 0 0 0 1.56 1.04H21a2 2 0 0 1 0 4h-.08A1.7 1.7 0 0 0 19.4 15Z" />
             </svg>
           </button>
+          {templateFillLeaves.length > 0 && (
+            <button type="button" className="secondary-action" onClick={() => void startChapterModeTask('template-fill')} disabled={taskBlocksGeneration}>
+              {templateFillRunning ? '正在填充模板' : '填充全部模板'}
+            </button>
+          )}
+          {pointToPointLeaves.length > 0 && (
+            <button type="button" className="secondary-action" onClick={() => void startChapterModeTask('point-to-point')} disabled={taskBlocksGeneration}>
+              {pointToPointRunning ? '正在生成应答表' : '生成全部应答表'}
+            </button>
+          )}
           {awaitingContentDecision ? (
             <>
               {unresolvedCount > 0 && (
@@ -1159,7 +1203,19 @@ function ContentEditPage({
                   <button type="button" className="secondary-action" onClick={cancelEditingContent}>取消</button>
                 </>
               ) : (
-                <button type="button" className="secondary-action" onClick={startEditingContent} disabled={!selectedItem || !selectedIsLeaf || taskBlocksGeneration}>编辑</button>
+                <>
+                  {selectedIsLeaf && selectedItem?.content_mode === 'template-fill' && (
+                    <button type="button" className="secondary-action" onClick={() => void startChapterModeTask('template-fill', [selectedItem.id])} disabled={taskBlocksGeneration}>
+                      {selectedContent.trim() ? '重新填充模板' : '填充模板'}
+                    </button>
+                  )}
+                  {selectedIsLeaf && selectedItem?.content_mode === 'point-to-point' && (
+                    <button type="button" className="secondary-action" onClick={() => void startChapterModeTask('point-to-point', [selectedItem.id])} disabled={taskBlocksGeneration}>
+                      {selectedContent.trim() ? '重新生成应答表' : '生成应答表'}
+                    </button>
+                  )}
+                  <button type="button" className="secondary-action" onClick={startEditingContent} disabled={!selectedItem || !selectedIsLeaf || taskBlocksGeneration}>编辑</button>
+                </>
               )}
             </div>
           </div>
@@ -1195,6 +1251,16 @@ function ContentEditPage({
                 : selectedItem.content_mode && selectedItem.content_mode !== 'ai-generate'
                 ? `${pendingModeDescriptions[selectedItem.content_mode]}${selectedItem.content_mode === 'other' && selectedItem.content_mode_note ? ` ${selectedItem.content_mode_note}` : ''}`
                 : taskInFlight ? '如果该小节正在生成，模型返回内容后会实时显示在这里。' : paused ? '任务已暂停，可先导出当前内容或点击继续。' : '点击生成正文后，后台会按 AI 生成小节生成内容。'}</p>
+              {selectedItem.content_mode === 'template-fill' && (
+                <button type="button" className="primary-action" onClick={() => void startChapterModeTask('template-fill', [selectedItem.id])} disabled={taskBlocksGeneration}>
+                  填充模板
+                </button>
+              )}
+              {selectedItem.content_mode === 'point-to-point' && (
+                <button type="button" className="primary-action" onClick={() => void startChapterModeTask('point-to-point', [selectedItem.id])} disabled={taskBlocksGeneration}>
+                  生成应答表
+                </button>
+              )}
             </div>
           ) : (
             <div className="markdown-empty-state content-generation-empty">

--- a/client/src/features/technical-plan/pages/ContentEditPage.tsx
+++ b/client/src/features/technical-plan/pages/ContentEditPage.tsx
@@ -1136,6 +1136,16 @@ function ContentEditPage({
             </button>
           )}
         </div>
+        {(templateFillTask?.status === 'error' || pointToPointTask?.status === 'error') && (
+          <div className="content-chapter-task-errors" role="alert">
+            {templateFillTask?.status === 'error' && (
+              <p className="content-chapter-task-error">模板填写失败：{templateFillTask.error || '未知错误'}</p>
+            )}
+            {pointToPointTask?.status === 'error' && (
+              <p className="content-chapter-task-error">应答表生成失败：{pointToPointTask.error || '未知错误'}</p>
+            )}
+          </div>
+        )}
       </section>
 
       {showIllustrationStats && (

--- a/client/src/features/technical-plan/pages/OutlineEditPage.tsx
+++ b/client/src/features/technical-plan/pages/OutlineEditPage.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties, DragEvent, ReactNode } from 'react';
 import { trackConfigUsage } from '../../../shared/analytics/analytics';
 import { AppDialog, AppSwitch, ProgressBar, useToast } from '../../../shared/ui';
 import type { BackgroundTaskState, OutlineSelectionItem, SaveOutlineRequest, SaveOutlineSelectionRequest, TechnicalPlanWorkflowKind } from '../types';
+import { useKnowledgeSearch } from '../../knowledge-base/hooks/useKnowledgeSearch';
 import type { KnowledgeBaseIndex, KnowledgeDocument } from '../../knowledge-base/types';
 import { OUTLINE_CONTENT_MODE_LABELS } from '../../../shared/types';
 import type { OutlineContentMode, OutlineData, OutlineExpansionMode, OutlineItem, OutlineMode, OutlineWordControlOptions } from '../../../shared/types';
@@ -352,6 +353,7 @@ function OutlineEditPage({
   const [draftStrictSectionWords, setDraftStrictSectionWords] = useState(outlineWordControlOptions.strictSectionWords);
   const [savingOutlineConfig, setSavingOutlineConfig] = useState(false);
   const [knowledgeSearch, setKnowledgeSearch] = useState('');
+  const { hits: knowledgeSearchHits } = useKnowledgeSearch(knowledgeSearch, { limit: 80 });
   const [expandedKnowledgeFolderIds, setExpandedKnowledgeFolderIds] = useState<Set<string>>(new Set());
   const [knowledgeIndex, setKnowledgeIndex] = useState<KnowledgeBaseIndex>(emptyKnowledgeIndex);
   const [loadingKnowledge, setLoadingKnowledge] = useState(false);
@@ -750,11 +752,12 @@ function OutlineEditPage({
           project_overview: outlineData?.project_overview || projectOverview,
         },
         reason: 'replace',
+        persistWordControlSnapshot: true,
       });
       setImportConfirmOpen(false);
       setImportPreviewOpen(false);
       setImportPreview(null);
-      showToast('目录已导入并替换当前目录。字数控制快照可能失效，需要的话请重新生成或重设字数。', 'success');
+      showToast('目录已导入。已按当前字数控制设置重写快照，可直接进入下一步。', 'success');
     } catch (error) {
       showToast(error instanceof Error ? error.message : '保存导入目录失败', 'error');
     }
@@ -1153,11 +1156,13 @@ function OutlineEditPage({
     const selectedDocuments = draftKnowledgeDocumentIds
       .map((documentId) => knowledgeIndex.documents.find((document) => document.id === documentId))
       .filter((document): document is KnowledgeDocument => Boolean(document));
+    const matchedDocumentIds = new Set(knowledgeSearchHits.map((hit) => hit.documentId));
+    const firstHitByDocument = new Map(knowledgeSearchHits.map((hit) => [hit.documentId, hit]));
     const visibleFolders = knowledgeIndex.folders.flatMap((folder) => {
       const folderDocuments = availableDocuments.filter((document) => document.folder_id === folder.id);
       const folderMatched = keyword ? includesKeyword(folder.name, keyword) : false;
       const documents = keyword
-        ? folderDocuments.filter((document) => folderMatched || includesKeyword(document.file_name, keyword))
+        ? folderDocuments.filter((document) => folderMatched || includesKeyword(document.file_name, keyword) || matchedDocumentIds.has(document.id))
         : folderDocuments;
 
       return documents.length ? [{ folder, documents }] : [];
@@ -1176,7 +1181,7 @@ function OutlineEditPage({
             value={knowledgeSearch}
             onChange={(event) => setKnowledgeSearch(event.target.value)}
             disabled={knowledgePickingDisabled}
-            placeholder="搜索文件夹或文档"
+            placeholder="搜索文件夹、文档或知识内容"
           />
           <span>{keyword ? `匹配 ${visibleDocumentCount} 个文档` : `共 ${availableDocuments.length} 个可用文档`}</span>
         </div>
@@ -1219,6 +1224,9 @@ function OutlineEditPage({
                               />
                               <strong title={document.file_name}>{document.file_name}</strong>
                               <small>{document.item_count || 0} 条</small>
+                              {firstHitByDocument.get(document.id)?.snippet ? (
+                                <em className="outline-knowledge-hit-snippet">{firstHitByDocument.get(document.id)?.snippet}</em>
+                              ) : null}
                             </label>
                           );
                         })}

--- a/client/src/features/technical-plan/pages/OutlineEditPage.tsx
+++ b/client/src/features/technical-plan/pages/OutlineEditPage.tsx
@@ -1,8 +1,8 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useEffect, useRef, useState } from 'react';
-import type { CSSProperties, DragEvent } from 'react';
+import type { CSSProperties, DragEvent, ReactNode } from 'react';
 import { trackConfigUsage } from '../../../shared/analytics/analytics';
-import { AppSwitch, ProgressBar, useToast } from '../../../shared/ui';
+import { AppDialog, AppSwitch, ProgressBar, useToast } from '../../../shared/ui';
 import type { BackgroundTaskState, OutlineSelectionItem, SaveOutlineRequest, SaveOutlineSelectionRequest, TechnicalPlanWorkflowKind } from '../types';
 import type { KnowledgeBaseIndex, KnowledgeDocument } from '../../knowledge-base/types';
 import { OUTLINE_CONTENT_MODE_LABELS } from '../../../shared/types';
@@ -366,6 +366,15 @@ function OutlineEditPage({
   const [savingOutlineSelection, setSavingOutlineSelection] = useState(false);
   const [draggingItemId, setDraggingItemId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<DropTargetState | null>(null);
+  const [importingOutline, setImportingOutline] = useState(false);
+  const [importPreviewOpen, setImportPreviewOpen] = useState(false);
+  const [importConfirmOpen, setImportConfirmOpen] = useState(false);
+  const [importPreview, setImportPreview] = useState<{
+    fileName?: string;
+    outline: OutlineItem[];
+    warnings: string[];
+    truncated?: boolean;
+  } | null>(null);
   const logListRef = useRef<HTMLDivElement | null>(null);
   const sortIdMapRef = useRef<Record<string, string>>({});
   const shownTaskErrorIdRef = useRef<string | null>(null);
@@ -690,9 +699,76 @@ function OutlineEditPage({
 
   const getMutationLockMessage = () => {
     if (generating) return '目录生成任务正在运行，当前目录暂不可编辑';
-    if (contentMutationLocked) return '正文生成任务正在运行或暂停中，请结束后再调整目录';
+    if (contentMutationLocked) return '正文或模板任务正在运行或暂停中，请结束后再调整目录';
     return '';
   };
+
+  const collectFilePaths = (files: FileList | File[] | null) => Array.from(files || [])
+    .map((file) => window.yibiao?.file.getPathForFile(file) || '')
+    .filter(Boolean);
+
+  const previewImportedOutline = async (filePaths?: string[]) => {
+    const lockMessage = getMutationLockMessage();
+    if (lockMessage) {
+      showToast(lockMessage, 'info');
+      return;
+    }
+    try {
+      setImportingOutline(true);
+      const result = await window.yibiao?.technicalPlan.importOutlineDocument(filePaths);
+      if (result?.canceled) return;
+      if (!result?.success || !result.outline?.length) {
+        showToast(result?.message || '没有识别到可用标题', 'error');
+        return;
+      }
+      setImportPreview({
+        fileName: result.fileName,
+        outline: result.outline,
+        warnings: result.warnings || [],
+        truncated: result.truncated,
+      });
+      setImportPreviewOpen(true);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '导入目录失败', 'error');
+    } finally {
+      setImportingOutline(false);
+    }
+  };
+
+  const confirmImportedOutline = async () => {
+    if (!importPreview?.outline.length) return;
+    const lockMessage = getMutationLockMessage();
+    if (lockMessage) {
+      showToast(lockMessage, 'info');
+      return;
+    }
+    try {
+      await onOutlineSaved({
+        outlineData: {
+          outline: importPreview.outline,
+          project_name: outlineData?.project_name,
+          project_overview: outlineData?.project_overview || projectOverview,
+        },
+        reason: 'replace',
+      });
+      setImportConfirmOpen(false);
+      setImportPreviewOpen(false);
+      setImportPreview(null);
+      showToast('目录已导入并替换当前目录。字数控制快照可能失效，需要的话请重新生成或重设字数。', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '保存导入目录失败', 'error');
+    }
+  };
+
+  const renderImportPreviewTree = (items: OutlineItem[], level = 0): ReactNode => items.map((item) => (
+    <div className="outline-import-preview-node" key={item.id} style={{ paddingLeft: `${level * 16}px` }}>
+      <strong>{item.id} {item.title}</strong>
+      {!item.children?.length && item.content_mode ? (
+        <em>{OUTLINE_CONTENT_MODE_LABELS[item.content_mode]}</em>
+      ) : null}
+      {item.children?.length ? renderImportPreviewTree(item.children, level + 1) : null}
+    </div>
+  ));
 
   const saveOutlineChange = async (outline: OutlineItem[], reason: SaveOutlineRequest['reason'], affectedNodeIds: string[] = []) => {
     if (!outlineData) {
@@ -1192,6 +1268,22 @@ function OutlineEditPage({
           )}
           <button
             type="button"
+            className="secondary-action"
+            onClick={() => { void previewImportedOutline(); }}
+            disabled={generating || sorting || contentMutationLocked || importingOutline}
+            onDragOver={(event: DragEvent<HTMLButtonElement>) => {
+              event.preventDefault();
+            }}
+            onDrop={(event: DragEvent<HTMLButtonElement>) => {
+              event.preventDefault();
+              const paths = collectFilePaths(event.dataTransfer.files);
+              if (paths.length) void previewImportedOutline(paths);
+            }}
+          >
+            {importingOutline ? '正在识别目录' : '导入目录'}
+          </button>
+          <button
+            type="button"
             className="outline-config-action"
             onClick={openGenerationDialog}
             disabled={generating || sorting || contentMutationLocked || !projectOverview}
@@ -1472,6 +1564,47 @@ function OutlineEditPage({
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
+
+      <AppDialog
+        open={importPreviewOpen}
+        onOpenChange={(open) => {
+          setImportPreviewOpen(open);
+          if (!open) setImportPreview(null);
+        }}
+        kicker="导入目录"
+        title={importPreview?.fileName ? `预览 ${importPreview.fileName}` : '预览导入目录'}
+        description="确认后将整树替换当前目录，并清空已有正文。不会自动重新生成 AI 目录。"
+        cardClassName="outline-import-preview-card"
+        actions={(
+          <>
+            <button type="button" className="secondary-action" onClick={() => { setImportPreviewOpen(false); setImportPreview(null); }}>取消</button>
+            <button type="button" className="primary-action" onClick={() => setImportConfirmOpen(true)} disabled={!importPreview?.outline.length}>下一步</button>
+          </>
+        )}
+      >
+        {importPreview?.warnings.length ? (
+          <div className="outline-import-preview-warnings">
+            {importPreview.warnings.map((warning) => <p key={warning}>{warning}</p>)}
+          </div>
+        ) : null}
+        <div className="outline-import-preview-tree">
+          {importPreview?.outline.length ? renderImportPreviewTree(importPreview.outline) : <p>没有可预览的目录</p>}
+        </div>
+      </AppDialog>
+
+      <AppDialog
+        open={importConfirmOpen}
+        onOpenChange={setImportConfirmOpen}
+        kicker="替换确认"
+        title="用导入目录替换当前目录？"
+        description="当前目录和已生成正文都会被清空。字数控制快照可能失效，需要的话请之后重新生成或重设字数。"
+        actions={(
+          <>
+            <button type="button" className="secondary-action" onClick={() => setImportConfirmOpen(false)}>返回预览</button>
+            <button type="button" className="primary-action" onClick={() => { void confirmImportedOutline(); }}>确认替换</button>
+          </>
+        )}
+      />
     </div>
   );
 }

--- a/client/src/features/technical-plan/pages/TechnicalPlanHome.tsx
+++ b/client/src/features/technical-plan/pages/TechnicalPlanHome.tsx
@@ -107,6 +107,8 @@ const resetState = {
   globalFactsAdjustmentTask: undefined,
   globalFacts: [] as GlobalFactGroupState[],
   contentGenerationTask: undefined,
+  templateFillTask: undefined,
+  pointToPointTask: undefined,
   contentGenerationOptions: undefined,
   contentGenerationSections: {},
   contentGenerationPlans: {},
@@ -284,7 +286,7 @@ function workflowLabel(kind: TechnicalPlanWorkflowKind) {
 }
 
 function hasRunningTechnicalPlanTask(state: TechnicalPlanState) {
-  return [state.bidSectionExtractionTask, state.bidAnalysisTask, state.outlineGenerationTask, state.outlineAdjustmentTask, state.globalFactsTask, state.globalFactsAdjustmentTask, state.contentGenerationTask]
+  return [state.bidSectionExtractionTask, state.bidAnalysisTask, state.outlineGenerationTask, state.outlineAdjustmentTask, state.globalFactsTask, state.globalFactsAdjustmentTask, state.contentGenerationTask, state.templateFillTask, state.pointToPointTask]
     .some((task) => task?.status === 'running' || task?.status === 'pausing');
 }
 
@@ -733,6 +735,8 @@ function TechnicalPlanHome({ workflowKind, registerLeaveGuard, onSectionChange }
             globalFactsAdjustmentTask: outlineDataReset ? undefined : prev.globalFactsAdjustmentTask,
             globalFacts: outlineDataReset ? [] : prev.globalFacts,
             contentGenerationTask: outlineDataReset ? undefined : prev.contentGenerationTask,
+            templateFillTask: outlineDataReset ? undefined : prev.templateFillTask,
+            pointToPointTask: outlineDataReset ? undefined : prev.pointToPointTask,
             contentGenerationOptions: outlineDataReset ? undefined : prev.contentGenerationOptions,
             contentGenerationSections: outlineDataReset ? {} : prev.contentGenerationSections,
             contentGenerationPlans: outlineDataReset ? {} : prev.contentGenerationPlans,
@@ -763,6 +767,8 @@ function TechnicalPlanHome({ workflowKind, registerLeaveGuard, onSectionChange }
             globalFactsAdjustmentTask: hasOwnField(technicalPlan, 'globalFactsAdjustmentTask') ? trimTaskLogs(technicalPlan.globalFactsAdjustmentTask) : prev.globalFactsAdjustmentTask,
             globalFacts: hasOwnField(technicalPlan, 'globalFacts') ? (technicalPlan.globalFacts || []) : prev.globalFacts,
             contentGenerationTask: hasOwnField(technicalPlan, 'contentGenerationTask') ? trimTaskLogs(technicalPlan.contentGenerationTask) : (outlineDataChanged ? undefined : prev.contentGenerationTask),
+            templateFillTask: hasOwnField(technicalPlan, 'templateFillTask') ? trimTaskLogs(technicalPlan.templateFillTask) : (outlineDataChanged ? undefined : prev.templateFillTask),
+            pointToPointTask: hasOwnField(technicalPlan, 'pointToPointTask') ? trimTaskLogs(technicalPlan.pointToPointTask) : (outlineDataChanged ? undefined : prev.pointToPointTask),
             contentGenerationSections: hasOwnField(technicalPlan, 'contentGenerationSections') ? (technicalPlan.contentGenerationSections || {}) : (outlineDataChanged ? {} : prev.contentGenerationSections),
             contentGenerationPlans: hasOwnField(technicalPlan, 'contentGenerationPlans') ? (technicalPlan.contentGenerationPlans || {}) : (outlineDataChanged ? {} : prev.contentGenerationPlans),
             contentIllustrationPlan: hasOwnField(technicalPlan, 'contentIllustrationPlan') ? technicalPlan.contentIllustrationPlan : (outlineDataChanged ? undefined : prev.contentIllustrationPlan),
@@ -839,6 +845,29 @@ function TechnicalPlanHome({ workflowKind, registerLeaveGuard, onSectionChange }
             contentGenerationPlans: hasOwnField(technicalPlan, 'contentGenerationPlans') ? (technicalPlan.contentGenerationPlans || {}) : prev.contentGenerationPlans,
             contentIllustrationPlan: hasOwnField(technicalPlan, 'contentIllustrationPlan') ? technicalPlan.contentIllustrationPlan : prev.contentIllustrationPlan,
             contentGenerationRuntime: hasOwnField(technicalPlan, 'contentGenerationRuntime') ? technicalPlan.contentGenerationRuntime : prev.contentGenerationRuntime,
+            outlineData: nextOutlineData,
+          };
+        }
+
+        if (taskType === 'template-fill-generation' || taskType === 'point-to-point-generation') {
+          const contentSection = event.contentSection;
+          const nextSections = hasOwnField(technicalPlan, 'contentGenerationSections')
+            ? (technicalPlan.contentGenerationSections || {})
+            : contentSection
+              ? { ...prev.contentGenerationSections, [contentSection.id]: contentSection }
+              : prev.contentGenerationSections;
+          const hasPatchOutlineData = hasOwnField(technicalPlan, 'outlineData') || hasOwnField(event, 'outlineData');
+          const patchOutlineData = hasOwnField(technicalPlan, 'outlineData') ? technicalPlan.outlineData : event.outlineData;
+          const nextOutlineData = hasPatchOutlineData
+            ? (patchOutlineData || null)
+            : contentSection?.content !== undefined && prev.outlineData
+              ? { ...prev.outlineData, outline: updateOutlineItemContent(prev.outlineData.outline, contentSection.id, contentSection.content) }
+              : prev.outlineData;
+          return {
+            ...prev,
+            templateFillTask: taskType === 'template-fill-generation' ? (latestTask || trimTaskLogs(technicalPlan.templateFillTask)) : prev.templateFillTask,
+            pointToPointTask: taskType === 'point-to-point-generation' ? (latestTask || trimTaskLogs(technicalPlan.pointToPointTask)) : prev.pointToPointTask,
+            contentGenerationSections: nextSections,
             outlineData: nextOutlineData,
           };
         }
@@ -1088,6 +1117,20 @@ function TechnicalPlanHome({ workflowKind, registerLeaveGuard, onSectionChange }
   const saveOutline = async (request: SaveOutlineRequest) => {
     const saved = await window.yibiao?.technicalPlan.saveOutline(request);
     setState((prev) => {
+      if (request.reason === 'replace') {
+        return {
+          ...prev,
+          ...(saved || {}),
+          outlineData: saved?.outlineData || request.outlineData,
+          contentGenerationSections: {},
+          contentGenerationPlans: {},
+          contentIllustrationPlan: undefined,
+          contentGenerationRuntime: undefined,
+          contentGenerationTask: undefined,
+          templateFillTask: undefined,
+          pointToPointTask: undefined,
+        };
+      }
       if (request.reason !== 'sort') {
         return { ...prev, ...(saved || {}), outlineData: saved?.outlineData || request.outlineData };
       }
@@ -1333,7 +1376,7 @@ function TechnicalPlanHome({ workflowKind, registerLeaveGuard, onSectionChange }
           referenceKnowledgeDocumentIds={state.referenceKnowledgeDocumentIds}
           outlineData={state.outlineData}
           task={state.outlineGenerationTask}
-          contentTaskStatus={state.contentGenerationTask?.status}
+          contentTaskStatus={[state.contentGenerationTask, state.templateFillTask, state.pointToPointTask].find((item) => item && ['running', 'pausing', 'paused'].includes(item.status))?.status}
           aiAdjustmentRunning={isOutlineAdjusting}
           onOutlineConfigChange={saveOutlineConfig}
           onOutlineSaved={saveOutline}
@@ -1363,6 +1406,8 @@ function TechnicalPlanHome({ workflowKind, registerLeaveGuard, onSectionChange }
           contentGenerationOptions={state.contentGenerationOptions}
           contentIllustrationPlan={state.contentIllustrationPlan}
           sections={state.contentGenerationSections}
+          templateFillTask={state.templateFillTask}
+          pointToPointTask={state.pointToPointTask}
           onContentGenerationOptionsChange={saveContentGenerationOptions}
           onContentSaved={saveChapterContent}
         />

--- a/client/src/features/technical-plan/services/bidAnalysisWorkflow.ts
+++ b/client/src/features/technical-plan/services/bidAnalysisWorkflow.ts
@@ -296,10 +296,23 @@ export const bidAnalysisTasks: BidAnalysisTaskDefinition[] = [
   "dispute_resolution": "争议解决"
 }`),
   },
+  {
+    id: 'bidBriefing',
+    label: '项目简报',
+    description: '根据已解析项整理一页项目简报，不进入默认关键项。',
+    required: false,
+    output: 'markdown',
+    buildTaskPrompt: () => '任务：根据已解析成功的招标要点整理一页项目简报。',
+  },
 ];
 
+export function isSelectableBidAnalysisTask(task: BidAnalysisTaskDefinition) {
+  return task.id !== 'bidBriefing';
+}
+
 export function getBidAnalysisTasks(mode: BidAnalysisMode) {
-  return mode === 'full' ? bidAnalysisTasks : bidAnalysisTasks.filter((task) => task.required);
+  const selectable = bidAnalysisTasks.filter(isSelectableBidAnalysisTask);
+  return mode === 'full' ? selectable : selectable.filter((task) => task.required);
 }
 
 export function getBidAnalysisTaskById(taskId: string) {

--- a/client/src/features/technical-plan/types.ts
+++ b/client/src/features/technical-plan/types.ts
@@ -6,7 +6,7 @@ export type BidAnalysisMode = 'key' | 'full' | 'custom';
 export type BidAnalysisTaskStatus = 'idle' | 'running' | 'success' | 'error';
 export type BidSectionMode = 'single' | 'multiple';
 export type BidSectionExtractionStatus = 'idle' | 'running' | 'success' | 'error';
-export type BackgroundTaskType = 'bid-section-extraction' | 'bid-analysis' | 'outline-generation' | 'outline-adjustment' | 'global-facts-generation' | 'global-facts-adjustment' | 'content-generation';
+export type BackgroundTaskType = 'bid-section-extraction' | 'bid-analysis' | 'outline-generation' | 'outline-adjustment' | 'global-facts-generation' | 'global-facts-adjustment' | 'content-generation' | 'template-fill-generation' | 'point-to-point-generation';
 export type BackgroundTaskStatus = 'running' | 'pausing' | 'paused' | 'success' | 'error';
 export type ContentGenerationSectionStatus = 'idle' | 'running' | 'success' | 'error' | 'ignored';
 export type ContentGenerationPhase = 'planning' | 'restoring' | 'generating' | 'section-word-adjusting' | 'original-auditing' | 'auditing' | 'table-cleaning' | 'final-section-word-adjusting' | 'total-word-adjusting' | 'illustration-planning' | 'illustration-generating' | 'done';
@@ -371,6 +371,8 @@ export interface TechnicalPlanState {
   globalFactsAdjustmentTask?: BackgroundTaskState;
   globalFacts: GlobalFactGroupState[];
   contentGenerationTask?: BackgroundTaskState;
+  templateFillTask?: BackgroundTaskState;
+  pointToPointTask?: BackgroundTaskState;
   contentGenerationOptions?: ContentGenerationOptions;
   contentGenerationSections: ContentGenerationSections;
   contentGenerationPlans: ContentGenerationPlans;

--- a/client/src/features/technical-plan/types.ts
+++ b/client/src/features/technical-plan/types.ts
@@ -22,6 +22,7 @@ export interface SaveOutlineRequest {
   reason: SaveOutlineReason;
   idMap?: Record<string, string>;
   affectedNodeIds?: string[];
+  persistWordControlSnapshot?: boolean;
 }
 
 export interface OutlineSelectionItem {

--- a/client/src/shared/types/exportFormat.ts
+++ b/client/src/shared/types/exportFormat.ts
@@ -82,6 +82,11 @@ export interface ImageStyleConfig {
   caption_italic: boolean;
 }
 
+export interface TextNormalizationConfig {
+  chinese_quotes: boolean;
+  strip_spaces: boolean;
+}
+
 // ── 纸张类型 ──────────────────────────────────────
 export const PAPER_SIZES = [
   { value: 'a4', label: 'A4', detail: '210×297mm 国际标准公文纸' },
@@ -145,6 +150,8 @@ export interface ExportFormatConfig {
   body_text: BodyTextStyleConfig;
   table: TableStyleConfig;
   image: ImageStyleConfig;
+  text_normalization: TextNormalizationConfig;
+  include_table_of_contents: boolean;
 }
 
 export interface ExportTemplateRecord {
@@ -385,6 +392,11 @@ const DEFAULT_IMAGE_STYLE: ImageStyleConfig = {
   caption_italic: false,
 };
 
+const DEFAULT_TEXT_NORMALIZATION: TextNormalizationConfig = {
+  chinese_quotes: false,
+  strip_spaces: false,
+};
+
 export const DEFAULT_HEADING_BORDER_CELL_COLORS = ['#eef5ff', '#f3f7ff', '#f8fbff', '#fbfdff', '#ffffff', '#ffffff'] as const;
 
 const DEFAULT_HEADING_BORDER: HeadingBorderConfig = {
@@ -416,6 +428,8 @@ export const DEFAULT_EXPORT_FORMAT: ExportFormatConfig = {
     { font: '宋体', size: '小四', alignment: '两端对齐', bold: false, text_color: '#243048', spacing_before_pt: 0, spacing_after_pt: 0, first_line_indent_chars: 0, line_spacing: 1, numbering_format: 'custom', numbering_template: '{tail}' },
   ],
   body_text: { ...DEFAULT_BODY_TEXT },
+  text_normalization: { ...DEFAULT_TEXT_NORMALIZATION },
+  include_table_of_contents: false,
   table: {
     border_width: DEFAULT_TABLE_STYLE.border_width,
     border_color: DEFAULT_TABLE_STYLE.border_color,

--- a/client/src/shared/types/ipc.ts
+++ b/client/src/shared/types/ipc.ts
@@ -6,7 +6,7 @@ import type { RejectionCheckWorkspacePatch, RejectionCheckWorkspaceState, Reject
 import type { BidAnalysisMode, BidAnalysisTaskState, BidSectionMode, ContentGenerationOptions, ContentGenerationPlanState, ContentGenerationProgressDetail, ContentGenerationRuntimeState, ContentGenerationSectionState, DetectedBidSection, GlobalFactGroupState, GlobalFactsMode, SaveOutlineRequest, SaveOutlineSelectionRequest, TechnicalPlanState, TechnicalPlanStep, TechnicalPlanWorkflowKind } from '../../features/technical-plan/types';
 import type { FeasibilityProjectInfo, FeasibilityReportState, FeasibilityReportStep, FeasibilitySaveOutlineRequest, FeasibilitySourceFile } from '../../features/feasibility-report/types';
 import type { ExportFormatConfig, ExportTemplateRecord } from './exportFormat';
-import type { OutlineData, OutlineExpansionMode, OutlineMode, OutlineWordControlOptions } from './outline';
+import type { OutlineData, OutlineExpansionMode, OutlineItem, OutlineMode, OutlineWordControlOptions } from './outline';
 
 export interface TaskEventTask {
   task_id: string;
@@ -51,6 +51,13 @@ export interface WordExportResult {
   path?: string;
   message?: string;
   warnings?: string[];
+}
+
+export interface CheckExcelExportResult {
+  success: boolean;
+  canceled?: boolean;
+  path?: string;
+  message?: string;
 }
 
 export interface RequiredOnlineServiceStatus {
@@ -609,6 +616,16 @@ export interface YibiaoBridge {
     saveOutlineConfig: (payload: { referenceKnowledgeDocumentIds: string[]; outlineMode?: OutlineMode; outlineExpansionMode?: OutlineExpansionMode; wordControlOptions: OutlineWordControlOptions }) => Promise<void>;
     saveOutlineSelection: (payload: SaveOutlineSelectionRequest) => Promise<{ success: boolean }>;
     saveOutline: (payload: SaveOutlineRequest) => Promise<Partial<TechnicalPlanState>>;
+    importOutlineDocument: (filePaths?: string[]) => Promise<{
+      success: boolean;
+      canceled?: boolean;
+      message?: string;
+      fileName?: string;
+      outline?: OutlineItem[];
+      warnings?: string[];
+      truncated?: boolean;
+    }>;
+    exportMarkdown: (payload: { content: string; defaultFileName?: string; title?: string }) => Promise<CheckExcelExportResult>;
     saveGlobalFactsConfig: (payload: { globalFactsMode: GlobalFactsMode }) => Promise<Partial<TechnicalPlanState>>;
     saveGlobalFacts: (globalFacts: GlobalFactGroupState[]) => Promise<Partial<TechnicalPlanState>>;
     saveContentGenerationOptions: (options: ContentGenerationOptions) => Promise<Partial<TechnicalPlanState>>;
@@ -636,15 +653,17 @@ export interface YibiaoBridge {
     saveUiState: (payload: Partial<Pick<DuplicateCheckWorkspaceState, 'step' | 'activeAnalysisTab'>>) => Promise<void>;
     updateState: (partial: DuplicateCheckWorkspacePatch) => Promise<void>;
     clear: () => Promise<{ success: boolean; message?: string }>;
+    exportExcel: () => Promise<CheckExcelExportResult>;
   };
   rejectionCheck: {
     loadState: () => Promise<RejectionCheckWorkspaceState>;
     importDocument: (role: RejectionDocumentRole, filePaths?: string[]) => Promise<{ success: boolean; message?: string }>;
     importTenderFromTechnicalPlan: () => Promise<{ success: boolean; message?: string }>;
     removeDocument: (role: RejectionDocumentRole, documentId?: string) => Promise<void>;
-    saveUiState: (payload: Partial<Pick<RejectionCheckWorkspaceState, 'step' | 'activeDocumentTab' | 'activeResultTab' | 'activeCheckResultTab' | 'customCheckItems' | 'checkOptions'>>) => Promise<void>;
+    saveUiState: (payload: Partial<Pick<RejectionCheckWorkspaceState, 'step' | 'activeDocumentTab' | 'activeResultTab' | 'activeCheckResultTab' | 'customCheckItems' | 'identityExtraKeywords' | 'checkOptions'>>) => Promise<void>;
     updateState: (partial: RejectionCheckWorkspacePatch) => Promise<void>;
     clear: () => Promise<{ success: boolean; message?: string }>;
+    exportExcel: () => Promise<CheckExcelExportResult>;
   };
   templates: {
     list: () => Promise<ExportTemplateRecord[]>;
@@ -660,6 +679,8 @@ export interface YibiaoBridge {
     suppressOutlineSelectionAutoConfirmation: (payload: { taskId: string }) => Promise<{ success: boolean }>;
     startGlobalFactsGeneration: (payload: unknown) => Promise<unknown>;
     startContentGeneration: (payload: unknown) => Promise<unknown>;
+    startTemplateFill: (payload?: { nodeIds?: string[] }) => Promise<unknown>;
+    startPointToPoint: (payload?: { nodeIds?: string[] }) => Promise<unknown>;
     pauseContentGeneration: () => Promise<unknown>;
     startRejectionItemsExtraction: (payload: unknown) => Promise<unknown>;
     startRejectionCheck: (payload: unknown) => Promise<unknown>;

--- a/client/src/shared/types/ipc.ts
+++ b/client/src/shared/types/ipc.ts
@@ -1,7 +1,7 @@
 import type { AiHttpErrorPayload, ChatCompletionRequest, JsonCompletionRequest } from './ai';
 import type { DuplicateCheckWorkspacePatch, DuplicateCheckWorkspaceState, FileSelectionResult } from './bid';
 import type { ClientConfig, ConfigSaveResult, ImageModelTestResult, ModelInfoResult, ModelListResult, UpdateChannel } from './config';
-import type { KnowledgeAnalysisSnapshot, KnowledgeBaseEvent, KnowledgeBaseIndex, KnowledgeBaseIndexMutationResult, KnowledgeBaseMutationResult, KnowledgeBaseRetryDocumentResult, KnowledgeBaseStartMatchingResult, KnowledgeBaseUploadResult, KnowledgeDocument, KnowledgeFolder, KnowledgeItem } from '../../features/knowledge-base/types';
+import type { KnowledgeAnalysisSnapshot, KnowledgeBaseEvent, KnowledgeBaseIndex, KnowledgeBaseIndexMutationResult, KnowledgeBaseMutationResult, KnowledgeBaseRetryDocumentResult, KnowledgeBaseStartMatchingResult, KnowledgeBaseUploadResult, KnowledgeDocument, KnowledgeFolder, KnowledgeItem, KnowledgeSearchRequest, KnowledgeSearchResult } from '../../features/knowledge-base/types';
 import type { RejectionCheckWorkspacePatch, RejectionCheckWorkspaceState, RejectionDocumentRole } from '../../features/rejection-check/types';
 import type { BidAnalysisMode, BidAnalysisTaskState, BidSectionMode, ContentGenerationOptions, ContentGenerationPlanState, ContentGenerationProgressDetail, ContentGenerationRuntimeState, ContentGenerationSectionState, DetectedBidSection, GlobalFactGroupState, GlobalFactsMode, SaveOutlineRequest, SaveOutlineSelectionRequest, TechnicalPlanState, TechnicalPlanStep, TechnicalPlanWorkflowKind } from '../../features/technical-plan/types';
 import type { FeasibilityProjectInfo, FeasibilityReportState, FeasibilityReportStep, FeasibilitySaveOutlineRequest, FeasibilitySourceFile } from '../../features/feasibility-report/types';
@@ -583,6 +583,7 @@ export interface YibiaoBridge {
     readMarkdown: (documentId: string) => Promise<string>;
     readItems: (documentId: string) => Promise<KnowledgeItem[]>;
     readAnalysis: (documentId: string) => Promise<KnowledgeAnalysisSnapshot>;
+    search: (payload: KnowledgeSearchRequest) => Promise<KnowledgeSearchResult>;
     onEvent: (callback: (event: KnowledgeBaseEvent) => void) => () => void;
   };
   technicalPlan: {

--- a/client/src/styles/feature-knowledge-base.css
+++ b/client/src/styles/feature-knowledge-base.css
@@ -42,8 +42,76 @@
 .knowledge-toolbar-actions {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
   justify-content: flex-end;
+}
+
+.knowledge-search-input {
+  width: min(320px, 42vw);
+  height: 38px;
+  padding: 0 12px;
+  color: var(--yb-text);
+  font-size: 13px;
+  background: #ffffff;
+  border: 1px solid var(--yb-border-soft);
+  border-radius: var(--yb-radius-md);
+  outline: none;
+}
+
+.knowledge-search-input:focus {
+  border-color: rgba(33, 116, 253, 0.5);
+  box-shadow: var(--yb-focus-ring);
+}
+
+.knowledge-search-results {
+  display: grid;
+  align-content: start;
+  gap: 8px;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px;
+}
+
+.knowledge-search-hit {
+  display: grid;
+  justify-items: start;
+  gap: 4px;
+  padding: 12px 14px;
+  text-align: left;
+  color: inherit;
+  background: var(--yb-bg);
+  border: 1px solid var(--yb-border-soft);
+  border-radius: var(--yb-radius-md);
+  cursor: pointer;
+}
+
+.knowledge-search-hit:hover {
+  border-color: rgba(33, 116, 253, 0.28);
+  box-shadow: 0 8px 20px rgba(33, 116, 253, 0.08);
+}
+
+.knowledge-search-hit-type {
+  color: var(--yb-primary);
+  font-size: 11px;
+  font-weight: 800;
+}
+
+.knowledge-search-hit strong {
+  color: var(--yb-text);
+  font-size: 14px;
+}
+
+.knowledge-search-hit small,
+.knowledge-search-hit p {
+  margin: 0;
+  color: var(--yb-text-muted);
+  font-size: 12px;
+}
+
+.knowledge-item-card.is-focused {
+  border-color: rgba(33, 116, 253, 0.42);
+  box-shadow: 0 0 0 3px rgba(33, 116, 253, 0.12);
 }
 
 .knowledge-toolbar-actions .secondary-action.is-active {

--- a/client/src/styles/feature-rejection-check.css
+++ b/client/src/styles/feature-rejection-check.css
@@ -164,6 +164,36 @@
   height: 100%;
 }
 
+.rejection-identity-extra-panel {
+  display: grid;
+  min-height: 0;
+  height: 100%;
+  grid-template-rows: auto minmax(0, 1fr);
+  gap: 16px;
+}
+
+.rejection-identity-checklist {
+  padding: 12px 14px;
+  border: 1px solid rgba(228, 233, 240, 0.88);
+  border-radius: var(--yb-radius-md);
+  background: rgba(248, 250, 252, 0.9);
+}
+
+.rejection-identity-checklist strong {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.rejection-identity-checklist ul {
+  margin: 0;
+  padding-left: 1.2em;
+  color: var(--yb-muted, #536176);
+}
+
+.rejection-identity-checklist li + li {
+  margin-top: 4px;
+}
+
 .rejection-check-result-panel {
   display: grid;
   height: 100%;

--- a/client/src/styles/feature-technical-plan.css
+++ b/client/src/styles/feature-technical-plan.css
@@ -1224,8 +1224,27 @@
 
 .content-generation-actions {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 10px;
+}
+
+.content-chapter-task-errors {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 6px;
+}
+
+.content-chapter-task-error {
+  margin: 0;
+  padding: 8px 10px;
+  color: var(--yb-danger);
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.18);
+  border-radius: var(--yb-radius-md);
+  font-size: 12px;
+  font-weight: 700;
 }
 
 .content-dev-stats-panel {
@@ -3420,6 +3439,15 @@
   display: grid;
   gap: 1px;
   padding: 0 6px 6px;
+}
+
+.outline-knowledge-hit-snippet {
+  grid-column: 1 / -1;
+  color: var(--yb-text-muted);
+  font-size: 11px;
+  font-style: normal;
+  line-height: 1.4;
+  white-space: normal;
 }
 
 .outline-knowledge-document.compact {

--- a/client/src/styles/feature-technical-plan.css
+++ b/client/src/styles/feature-technical-plan.css
@@ -440,6 +440,32 @@
   color: var(--yb-danger);
 }
 
+.bid-briefing-body {
+  display: grid;
+  align-content: start;
+  gap: 14px;
+  min-height: 0;
+  overflow: auto;
+  padding: 0 4px 16px;
+}
+
+.bid-briefing-incomplete {
+  margin: 0;
+  padding: 10px 12px;
+  color: #8a5a12;
+  background: rgba(245, 176, 65, 0.12);
+  border: 1px solid rgba(245, 176, 65, 0.28);
+  border-radius: var(--yb-radius-md);
+  font-size: 13px;
+}
+
+.bid-briefing-card {
+  padding: 16px 18px;
+  background: #fff;
+  border: 1px solid rgba(33, 116, 253, 0.12);
+  border-radius: var(--yb-radius-lg);
+}
+
 .bid-analysis-reader {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
@@ -2339,6 +2365,39 @@
 .outline-config-action:disabled {
   cursor: not-allowed;
   opacity: 0.5;
+}
+
+.outline-import-preview-card {
+  width: min(720px, calc(100vw - 40px));
+}
+
+.outline-import-preview-warnings {
+  margin-bottom: 12px;
+  color: #8a5a12;
+  font-size: 13px;
+}
+
+.outline-import-preview-tree {
+  max-height: min(420px, 50vh);
+  overflow: auto;
+  padding: 8px 0;
+}
+
+.outline-import-preview-node {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.outline-import-preview-node strong {
+  font-size: 13px;
+}
+
+.outline-import-preview-node em {
+  color: var(--yb-text-muted);
+  font-size: 12px;
+  font-style: normal;
 }
 
 .outline-generation-config-card {

--- a/sql/workspace_schema.sql
+++ b/sql/workspace_schema.sql
@@ -4,7 +4,7 @@
 -- 1. 本文件用于开源开发者阅读、评审和排查问题，展示 workspace/yibiao.sqlite 的目标完整表结构。
 -- 2. 用户运行客户端时不需要手动执行本文件。
 -- 3. 客户端运行时建表和升级以 Electron Main 侧 migration 代码为准。
--- 4. 当前运行代码已落地 technical_plan_* v1、duplicate_check_* / rejection_check_* v2、knowledge_* v3、technical_plan_global_fact_groups v4、标段兼容 v5/v6、标段选择 v7、旧待选择标段兼容字段 v8、工作流类型和原方案文件状态 v9、招标解析项选择配置 v10、知识库排序 v11、废标项检查多投标文件 v12、已有方案目录配置 v13、多标段优化状态 v14、导出模板库 v15、多招标文件 v16、全文图片编排 v17、目录字数控制 v18、全局事实补全模式 v22、可行性研究报告 v23、暗标检查 v24 目标结构。
+-- 4. 当前运行代码已落地 technical_plan_* v1、duplicate_check_* / rejection_check_* v2、knowledge_* v3、technical_plan_global_fact_groups v4、标段兼容 v5/v6、标段选择 v7、旧待选择标段兼容字段 v8、工作流类型和原方案文件状态 v9、招标解析项选择配置 v10、知识库排序 v11、废标项检查多投标文件 v12、已有方案目录配置 v13、多标段优化状态 v14、导出模板库 v15、多招标文件 v16、全文图片编排 v17、目录字数控制 v18、全局事实补全模式 v22、可行性研究报告 v23、暗标检查 v24、知识库全局检索 v25 目标结构。
 -- 5. 每次表结构调整后，需要同步更新本文件和 runtime migration 版本。
 -- 6. 本文件不保存历史版本，每次更新都写入最新目标完整结构。
 
@@ -14,7 +14,7 @@ PRAGMA busy_timeout = 5000;
 
 -- 目标完整结构版本。
 -- 运行时代码应通过 PRAGMA user_version 判断是否需要自动升级。
-PRAGMA user_version = 24;
+PRAGMA user_version = 25;
 
 -- ============================================================================
 -- 技术方案 technical_plan_*（v1 已落地）
@@ -850,6 +850,38 @@ CREATE TABLE IF NOT EXISTS knowledge_match_batches (
 
 CREATE INDEX IF NOT EXISTS idx_knowledge_match_batches_status
 ON knowledge_match_batches(document_id, status, batch_index);
+
+-- 知识库全局检索索引（v25）。
+-- knowledge_search_rows 保存文档 / 条目 / 未筛除 block 的可检索文本；FTS5 用 trigram 做中文子串匹配。
+CREATE TABLE IF NOT EXISTS knowledge_search_rows (
+  id INTEGER PRIMARY KEY,
+  entity_key TEXT NOT NULL UNIQUE,
+  entity_type TEXT NOT NULL,
+  document_id TEXT NOT NULL,
+  folder_id TEXT NOT NULL DEFAULT '',
+  item_id TEXT NOT NULL DEFAULT '',
+  block_id TEXT NOT NULL DEFAULT '',
+  file_name TEXT NOT NULL DEFAULT '',
+  title TEXT NOT NULL DEFAULT '',
+  resume TEXT NOT NULL DEFAULT '',
+  body TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_search_rows_document
+ON knowledge_search_rows(document_id);
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_search_rows_folder
+ON knowledge_search_rows(folder_id, entity_type);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS knowledge_search_fts USING fts5(
+  file_name,
+  title,
+  resume,
+  body,
+  content='knowledge_search_rows',
+  content_rowid='id',
+  tokenize='trigram'
+);
 
 -- ============================================================================
 -- 导出模板 export_templates（v15 目标设计）

--- a/sql/workspace_schema.sql
+++ b/sql/workspace_schema.sql
@@ -4,7 +4,7 @@
 -- 1. 本文件用于开源开发者阅读、评审和排查问题，展示 workspace/yibiao.sqlite 的目标完整表结构。
 -- 2. 用户运行客户端时不需要手动执行本文件。
 -- 3. 客户端运行时建表和升级以 Electron Main 侧 migration 代码为准。
--- 4. 当前运行代码已落地 technical_plan_* v1、duplicate_check_* / rejection_check_* v2、knowledge_* v3、technical_plan_global_fact_groups v4、标段兼容 v5/v6、标段选择 v7、旧待选择标段兼容字段 v8、工作流类型和原方案文件状态 v9、招标解析项选择配置 v10、知识库排序 v11、废标项检查多投标文件 v12、已有方案目录配置 v13、多标段优化状态 v14、导出模板库 v15、多招标文件 v16、全文图片编排 v17、目录字数控制 v18、全局事实补全模式 v22、可行性研究报告 v23 目标结构。
+-- 4. 当前运行代码已落地 technical_plan_* v1、duplicate_check_* / rejection_check_* v2、knowledge_* v3、technical_plan_global_fact_groups v4、标段兼容 v5/v6、标段选择 v7、旧待选择标段兼容字段 v8、工作流类型和原方案文件状态 v9、招标解析项选择配置 v10、知识库排序 v11、废标项检查多投标文件 v12、已有方案目录配置 v13、多标段优化状态 v14、导出模板库 v15、多招标文件 v16、全文图片编排 v17、目录字数控制 v18、全局事实补全模式 v22、可行性研究报告 v23、暗标检查 v24 目标结构。
 -- 5. 每次表结构调整后，需要同步更新本文件和 runtime migration 版本。
 -- 6. 本文件不保存历史版本，每次更新都写入最新目标完整结构。
 
@@ -14,7 +14,7 @@ PRAGMA busy_timeout = 5000;
 
 -- 目标完整结构版本。
 -- 运行时代码应通过 PRAGMA user_version 判断是否需要自动升级。
-PRAGMA user_version = 23;
+PRAGMA user_version = 24;
 
 -- ============================================================================
 -- 技术方案 technical_plan_*（v1 已落地）
@@ -466,6 +466,7 @@ CREATE TABLE IF NOT EXISTS rejection_check_meta (
   active_result_tab TEXT NOT NULL DEFAULT 'analysis',
   active_check_result_tab TEXT NOT NULL DEFAULT 'rejection',
   custom_check_items TEXT NOT NULL DEFAULT '',
+  identity_extra_keywords TEXT NOT NULL DEFAULT '',
   check_options_json TEXT,
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL
@@ -559,8 +560,8 @@ CREATE TABLE IF NOT EXISTS rejection_check_extraction (
   updated_at TEXT
 );
 
--- 三类检查结果状态。
--- result_type: rejection / typo / logic。
+-- 四类检查结果状态。
+-- result_type: rejection / typo / logic / identity。
 CREATE TABLE IF NOT EXISTS rejection_check_results (
   result_type TEXT PRIMARY KEY,
   status TEXT NOT NULL DEFAULT 'idle',
@@ -627,6 +628,24 @@ CREATE TABLE IF NOT EXISTS rejection_check_logic_findings (
 
 CREATE INDEX IF NOT EXISTS idx_rejection_check_logic_order
 ON rejection_check_logic_findings(sort_order);
+
+-- 暗标检查结果。
+CREATE TABLE IF NOT EXISTS rejection_check_identity_findings (
+  finding_id TEXT PRIMARY KEY,
+  bid_document_id TEXT,
+  category TEXT NOT NULL,
+  matched_text TEXT NOT NULL,
+  original_excerpt TEXT NOT NULL,
+  location_hint TEXT NOT NULL,
+  risk_reason TEXT NOT NULL,
+  suggestion TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_rejection_check_identity_order
+ON rejection_check_identity_findings(sort_order);
 
 -- ============================================================================
 -- 知识库 knowledge_*（v3 目标设计）


### PR DESCRIPTION
本 PR 在既有技术方案 / 废标项 / 知识库页面上补齐正式版缺口，不新增菜单。按确认范围只做 E 和 F，未做知识块配图（G）和商务标（H）。

## 第一轮（1–7）
- 废标 / 查重 Excel 导出、暗标版 Word 预设、中文引号与去空格
- Word 目录与 `outline-{id}` 书签，`{{page:outline-<id>}}` 转为 PAGEREF
- 废标项检查增加暗标检查（第四项），schema v24
- Word / Markdown 目录导入，叶子支持点对点 / 模板填写
- 模板填写与点对点应答表后台任务

## 第二轮（E + F）
- **E1** 导入目录后按当前字数控制设置写入快照，可直接进入下一步
- **E2** 废标项开关仍默认开启且不可关；解析未完成时仍可检查暗标 / 错别字 / 逻辑
- **E3** 正文页在「填充全部模板 / 生成全部应答表」旁常驻显示任务失败原因
- **F** schema v25 知识库 FTS 全局检索；提示词只注入叶子勾选的知识条目

## 安全与隐私
- 仓库无 API Key、Token、`user_config`、真实单位 / 人员名
- 知识库 FTS 只在本机检索，不外发
- 模板填写已与正文生成对齐：叶子未勾知识条目时不注入参考文档正文

未做：知识块配图、商务标 MVP、向量检索、新顶级菜单。