### PR TITLE
feat: support standalone technical volume outlines

### DIFF
--- a/client/electron/services/outlineGenerationTaskV2.cjs
+++ b/client/electron/services/outlineGenerationTaskV2.cjs
@@ -488,11 +488,20 @@ function buildKnowledgeFiles(knowledgeBaseService, documentIds) {
     .filter((file) => file.content);
 }
 
-function createInitialPrompt(taskInstruction) {
+function createInitialPrompt(taskInstruction, { standaloneTechnical = false } = {}) {
+  const goal = standaloneTechnical
+    ? '我们的目标是为单独装订的技术方案准备一级目录。一级目录必须直接对应技术评分大项。'
+    : '我们的目标是为编写响应文件/投标文件准备一级目录。';
+  const modeRequirements = standaloneTechnical
+    ? `6. 本模式只生成技术方案独立分册：只能保留适合展开技术正文的评分大项，attr 必须为“技术”，content_mode 必须为 ai-generate。
+7. 每个一级目录直接对应一个技术评分大项，并保持评分大项的原顺序和正式表述；不得创建“技术方案”“监理大纲”“监理大纲（暗标）”“施工组织设计”“技术标”等外层总目录，也不得加入商务、资信、投标函、授权委托书等非技术章节。
+8. 完整结构示例：{"outline":[{"id":"1","title":"评分大项一","description":"评分大项一的技术响应范围","attr":"技术","content_mode":"ai-generate"},{"id":"2","title":"评分大项二","description":"评分大项二的技术响应范围","attr":"技术","content_mode":"ai-generate"}]}。`
+    : `6. 每个一级目录当前都是叶子节点，必须根据它后续应采用的内容处理方式填写 content_mode：技术方案正文使用 ai-generate；需要从招标文件提取并套用表格或格式的商务、资信材料使用 template-fill；需要在全部正文完成并确定 Word 页码后回填的点对点应答表使用 point-to-point；无法归类的特殊内容使用 other，并在 content_mode_note 说明原因。
+7. 完整结构示例：{"outline":[{"id":"1","title":"技术方案","description":"技术方案目录说明","attr":"技术","content_mode":"ai-generate"},{"id":"2","title":"特殊资料","description":"特殊资料目录说明","attr":"其他","content_mode":"other","content_mode_note":"说明特殊处理原因"}]}。content_mode_note 只在 content_mode=other 且确有说明时填写。`;
   return `请只在当前工作目录内工作。
 
 任务：
-我们的目标是为编写响应文件/投标文件准备一级目录。
+${goal}
 ${taskInstruction}
 
 请生成一级目录 JSON，并将结果写入 ${OUTLINE_OUTPUT_FILE}。
@@ -503,10 +512,9 @@ ${taskInstruction}
 3. title 必须是可直接用于投标文件目录的正式标题，不得包含“附件1”“附件一”“第一章”等编号或前缀。
 4. description 是目录说明。
 5. attr 必须从“通用”“商务”“资信”“技术”“其他”中选择。
-6. 每个一级目录当前都是叶子节点，必须根据它后续应采用的内容处理方式填写 content_mode：技术方案正文使用 ai-generate；需要从招标文件提取并套用表格或格式的商务、资信材料使用 template-fill；需要在全部正文完成并确定 Word 页码后回填的点对点应答表使用 point-to-point；无法归类的特殊内容使用 other，并在 content_mode_note 说明原因。
-7. ${OUTLINE_OUTPUT_FILE} 必须是纯 JSON，不包含 Markdown 代码块或解释文字。
-8. 完整结构示例：{"outline":[{"id":"1","title":"技术方案","description":"技术方案目录说明","attr":"技术","content_mode":"ai-generate"},{"id":"2","title":"特殊资料","description":"特殊资料目录说明","attr":"其他","content_mode":"other","content_mode_note":"说明特殊处理原因"}]}。content_mode_note 只在 content_mode=other 且确有说明时填写。
-9. 程序已为 ${OUTLINE_OUTPUT_FILE} 预置 Schema。写入后调用 json-validation，只传 {"file_path":"${OUTLINE_OUTPUT_FILE}"}；校验失败后必须先修改文件，再重新校验。`;
+${modeRequirements}
+9. ${OUTLINE_OUTPUT_FILE} 必须是纯 JSON，不包含 Markdown 代码块或解释文字。
+10. 程序已为 ${OUTLINE_OUTPUT_FILE} 预置 Schema。写入后调用 json-validation，只传 {"file_path":"${OUTLINE_OUTPUT_FILE}"}；校验失败后必须先修改文件，再重新校验。`;
 }
 
 function createLeafAllocationPrompt() {
@@ -554,27 +562,34 @@ ${originalList}
 6. 不要修改 ${OUTLINE_OUTPUT_FILE}。`;
 }
 
-function createScorePlanningPrompt({ templateExtractionSkipped = false } = {}) {
+function createScorePlanningPrompt({ templateExtractionSkipped = false, standaloneTechnical = false } = {}) {
   const templateInstruction = templateExtractionSkipped
     ? '程序已跳过投标模版提取，不要判断或补做该步骤，直接执行当前目录规划。'
     : '';
+  const placementInstruction = standaloneTechnical
+    ? `4. 当前采用“技术方案独立成册”：${OUTLINE_OUTPUT_FILE} 中每个一级根节点本身就应对应一个技术评分大项。每个根节点建立一个 branch，score_item_level 固定为 1，mappings 只填写与该根标题对应的评分大项，target_title 必须与 root_title 完全一致；不得再创建“技术方案”“监理大纲”等外层分支。
+5. 一级根节点与评分大项默认严格一一对应；发现缺失、重复、合并或顺序不一致时，必须作为一级目录调整向用户说明并取得批准。detail_points 只用于后续生成根节点以下的目录。`
+    : `4. 判断技术方案位于哪些目录分支，以及每个分支内评分项对应节点应统一处于哪个层级。不同分支可以使用不同层级，不预设必须是二级目录。优先选择 attr=技术且 content_mode=ai-generate 的一级目录；template-fill、point-to-point 和 other 是特殊处理叶子，不得作为普通技术方案分支展开，除非先向用户说明并取得调整批准。
+5. 默认每个评分项对应一个独立同层级节点，节点标题与评分大项基本一一对应；detail_points 用于后续生成更下级目录。`;
+  const planExample = standaloneTechnical
+    ? `{"branches":[{"branch_id":"B1","root_id":"1","root_title":"评分大项一","score_item_level":1,"mappings":[{"requirement_id":"R1","target_title":"评分大项一"}]}],"extra_titles":[],"allow_root_changes":false}`
+    : `{"branches":[{"branch_id":"B1","root_id":"2","root_title":"技术方案","score_item_level":2,"mappings":[{"requirement_id":"R1","target_title":"评分大项目录标题","additional_titles":["经批准拆分出的同级标题"],"adjustment_note":"用户批准的调整说明"}]}],"extra_titles":[{"branch_id":"B1","title":"经批准增加的同层级标题","reason":"增加原因"}],"allow_root_changes":false}`;
   return `用户已经确认最终保留的一级目录，${OUTLINE_OUTPUT_FILE} 已由程序重新整理并编号。工作区也已加入技术评分信息和用户选择的参考资料。${templateInstruction ? `\n${templateInstruction}` : ''}
 
 请完成技术评分项结构化和目录规划：
 1. 阅读 ${OUTLINE_OUTPUT_FILE}、技术评分信息.md，以及存在的原方案.md 和参考知识库目录。
 2. 只从技术评分信息.md 的“技术评分项”中提取适合在技术方案中一一响应、展开编写的评分大项。“技术评分要求”只能作为评分标准、扣分规则和编写约束，不得提取为评分项。
 3. 将评分大项写入 ${TECHNICAL_SCORE_GROUPS_FILE}，完整结构为 {"groups":[{"requirement_id":"R1","title":"评分大项","description":"关注内容","detail_points":["关键评分细项"]}]}。根对象只能包含 groups；保持原顺序、专业术语和关键评分细项，requirement_id 使用连续的 R1、R2 格式。
-4. 判断技术方案位于哪些目录分支，以及每个分支内评分项对应节点应统一处于哪个层级。不同分支可以使用不同层级，不预设必须是二级目录。优先选择 attr=技术且 content_mode=ai-generate 的一级目录；template-fill、point-to-point 和 other 是特殊处理叶子，不得作为普通技术方案分支展开，除非先向用户说明并取得调整批准。
-5. 默认每个评分项对应一个独立同层级节点，节点标题与评分大项基本一一对应；detail_points 用于后续生成更下级目录。
+${placementInstruction}
 6. 只有以下偏离需要用户批准：合并或拆分评分项、遗漏评分项对应节点、增加评分项中不存在的同层级大项、改变分支评分项目标层级，以及新增、删除、合并或调整用户已确认的一级目录。普通标题规范化和评分项下级目录扩展不需要询问。
 7. 无论是否存在偏离，都必须调用一次 ask-user 让用户确认。没有偏离时，question 只说明你分析得出的技术方案所在目录和评分项所在层级，最多使用两句话且不要使用列表；存在偏离时，只补充实际需要用户批准的偏离及影响，存在多个实际确认事项时才使用简单 Markdown 分行列出。question、选项名称和选项说明不得复述、概括或改写本任务 Prompt 中的要求，只呈现你分析后确实需要用户确认的结论或不确定事项。第一项给出推荐方案；另提供一个名为“调整目录安排”等明确业务名称的选项并设置 custom=true，让用户说明希望调整的位置或层级，其他选项均设置 custom=false。
-8. 根据用户回答写入 ${SCORE_DIRECTORY_PLAN_FILE}。完整字段层级示例：{"branches":[{"branch_id":"B1","root_id":"2","root_title":"技术方案","score_item_level":2,"mappings":[{"requirement_id":"R1","target_title":"评分大项目录标题","additional_titles":["经批准拆分出的同级标题"],"adjustment_note":"用户批准的调整说明"}]}],"extra_titles":[{"branch_id":"B1","title":"经批准增加的同层级标题","reason":"增加原因"}],"allow_root_changes":false}。branches 中每个分支填写唯一且后续保持不变的 branch_id，并用当前 ${OUTLINE_OUTPUT_FILE} 中尚未调整的一级目录编号和标题填写 root_id、root_title；统一填写 score_item_level，并让每个 requirement_id 在 mappings 中恰好出现一次。后续新增、重排或改名一级目录时，branch_id 仍用于稳定关联同一技术分支，不能随 root_id 改变；程序会在完整目录重新编号后同步 root_id 和 root_title。默认一一对应；经用户批准合并时，多个 mapping 可以使用相同 target_title；经用户批准拆分时才填写 mapping.additional_titles；合并或拆分时才填写 adjustment_note。extra_titles 必须位于根对象，经批准增加同层级大项时才写入条目，否则使用空数组。
+8. 根据用户回答写入 ${SCORE_DIRECTORY_PLAN_FILE}。完整字段层级示例：${planExample}。branches 中每个分支填写唯一且后续保持不变的 branch_id，并用当前 ${OUTLINE_OUTPUT_FILE} 中尚未调整的一级目录编号和标题填写 root_id、root_title；统一填写 score_item_level，并让每个 requirement_id 在 mappings 中恰好出现一次。后续新增、重排或改名一级目录时，branch_id 仍用于稳定关联同一技术分支，不能随 root_id 改变；程序会在完整目录重新编号后同步 root_id 和 root_title。默认一一对应；经用户批准合并时，多个 mapping 可以使用相同 target_title；经用户批准拆分时才填写 mapping.additional_titles；合并或拆分时才填写 adjustment_note。extra_titles 必须位于根对象，经批准增加同层级大项时才写入条目，否则使用空数组。
 9. 默认锁定一级目录，allow_root_changes=false；只有用户明确批准一级目录调整时才设为 true。
 10. 程序已为 ${TECHNICAL_SCORE_GROUPS_FILE} 和 ${SCORE_DIRECTORY_PLAN_FILE} 预置 Schema。分别调用 json-validation 校验，调用时只传 file_path；校验失败后必须先修改对应文件，再重新校验。
 11. 此阶段不要修改 ${OUTLINE_OUTPUT_FILE}。`;
 }
 
-function createChildrenPrompt({ hasOriginalPlan, originalOnly, targetLeafCount, allowRootChanges }) {
+function createChildrenPrompt({ hasOriginalPlan, originalOnly, targetLeafCount, allowRootChanges, standaloneTechnical }) {
   const branchInstruction = !hasOriginalPlan
     ? '没有原方案时，以技术评分信息.md 为主要依据生成目录。'
     : originalOnly
@@ -586,12 +601,18 @@ function createChildrenPrompt({ hasOriginalPlan, originalOnly, targetLeafCount, 
   const rootInstruction = allowRootChanges
     ? `用户已批准 ${SCORE_DIRECTORY_PLAN_FILE} 中记录的一级目录调整，只能按该规划进行必要修改并重新编号。`
     : '一级目录的数量、顺序、id、title、description、attr 均已由用户确认，必须保持不变；未扩展为父节点的一级目录还必须保留其 content_mode。';
+  const mappingInstruction = standaloneTechnical
+    ? '每个 branch 的 score_item_level=1，现有一级根节点本身就是评分项映射节点。不得在根节点下面再次生成同名评分项；只根据 detail_points、招标要求和专业逻辑生成其二级及以下目录。'
+    : '每个 branch 的 mappings 必须在该分支的 score_item_level 层级生成对应节点。';
+  const outlineExample = standaloneTechnical
+    ? `{"outline":[{"id":"1","title":"评分大项一","description":"评分大项说明","attr":"技术","branch_id":"B1","children":[{"id":"1.1","title":"响应内容一","description":"具体响应内容","content_mode":"ai-generate"},{"id":"1.2","title":"响应内容二","description":"具体响应内容","content_mode":"ai-generate"}]}]}`
+    : `{"outline":[{"id":"1","title":"技术应答表","description":"应答表说明","attr":"技术","content_mode":"point-to-point"},{"id":"2","title":"技术方案","description":"技术方案说明","attr":"技术","branch_id":"B1","children":[{"id":"2.1","title":"评分大项","description":"评分大项说明","children":[{"id":"2.1.1","title":"具体方案一","description":"具体方案说明","content_mode":"ai-generate"},{"id":"2.1.2","title":"具体方案二","description":"具体方案说明","content_mode":"ai-generate"}]},{"id":"2.2","title":"另一评分大项","description":"评分大项说明","content_mode":"ai-generate"}]}]}`;
   return `请继续使用当前上下文，为 ${OUTLINE_OUTPUT_FILE} 生成完整目录。生成方式和处理顺序由你自主决定，但必须严格遵循评分项目录规划。
 
 要求：
 1. ${branchInstruction}
 2. 以 ${TECHNICAL_SCORE_GROUPS_FILE} 为技术评分项权威清单，以 ${SCORE_DIRECTORY_PLAN_FILE} 为评分项与目录位置的权威规划。
-3. 每个 branch 的 mappings 必须在该分支的 score_item_level 层级生成对应节点。branch_id 是技术分支稳定标识：对应的最终一级目录必须保留同名 branch_id，即使一级目录新增、删除、改名、重排或重新编号也不得改变；非技术分支一级目录不要填写 branch_id。默认每个评分项形成一个独立节点；多个 mapping 使用相同 target_title 表示用户已批准合并，additional_titles 表示用户已批准将该评分项拆成多个同级节点。
+3. ${mappingInstruction} branch_id 是技术分支稳定标识：对应的最终一级目录必须保留同名 branch_id，即使一级目录新增、删除、改名、重排或重新编号也不得改变；非技术分支一级目录不要填写 branch_id。默认每个评分项形成一个独立节点；多个 mapping 使用相同 target_title 表示用户已批准合并，additional_titles 表示用户已批准将该评分项拆成多个同级节点。
 4. mappings 中的 target_title 是评分项对应节点标题，必须基本保持评分大项的专业表述；detail_points 主要用于生成其下级目录。
 5. extra_titles 是用户已批准增加的同层级大项；除此之外不得自行增加技术评分项中不存在的同层级标题。
 6. “技术评分要求”只能作为评分标准、扣分口径、判定规则和目录说明约束，不能生成独立评分项节点。
@@ -603,7 +624,7 @@ function createChildrenPrompt({ hasOriginalPlan, originalOnly, targetLeafCount, 
 12. 任意非叶子节点的 children 至少包含两个节点，不要创建只有一个子节点的冗余层级。
 13. 目录层级可变，但最多六级；一级目录包含 attr，子目录不包含 attr。所有 id 必须使用层级点号编号：一级为 1、2，二级为 2.1、2.2，三级为 2.1.1、2.1.2，后续层级依此类推，并与实际父子位置一致。
 14. title 只写纯标题，不包含章节编号或 Markdown 标记。
-15. ${OUTLINE_OUTPUT_FILE} 的完整结构示例：{"outline":[{"id":"1","title":"技术应答表","description":"应答表说明","attr":"技术","content_mode":"point-to-point"},{"id":"2","title":"技术方案","description":"技术方案说明","attr":"技术","branch_id":"B1","children":[{"id":"2.1","title":"评分大项","description":"评分大项说明","children":[{"id":"2.1.1","title":"具体方案一","description":"具体方案说明","content_mode":"ai-generate"},{"id":"2.1.2","title":"具体方案二","description":"具体方案说明","content_mode":"ai-generate"}]},{"id":"2.2","title":"另一评分大项","description":"评分大项说明","content_mode":"ai-generate"}]}]}。branch_id 只写在评分规划对应的技术一级目录上；示例只说明字段位置和编号方式，实际层级与标题必须按任务材料生成。
+15. ${OUTLINE_OUTPUT_FILE} 的完整结构示例：${outlineExample}。branch_id 只写在评分规划对应的技术一级目录上；示例只说明字段位置和编号方式，实际层级与标题必须按任务材料生成。
 16. 程序已为 ${OUTLINE_OUTPUT_FILE} 预置 Schema。直接覆盖写回该文件，完成后调用 json-validation 校验，只传 file_path；校验失败后必须先修改文件，再重新校验。`;
 }
 
@@ -682,6 +703,7 @@ function buildOpenXmlToolOptions(workspaceStore, openXmlHelperService) {
 async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowledgeBaseService, openXmlHelperService, updateTask, checkpointTask, taskControl, payload }) {
   const storedPlan = workspaceStore.loadTechnicalPlan() || {};
   const restoringOutlineSelection = payload?.agent_resume?.phase === 'outline-selection';
+  const standaloneTechnical = storedPlan.outlineMode === 'standalone-technical';
   const hasOriginalPlan = Boolean(storedPlan.originalPlanFile);
   const originalOnly = hasOriginalPlan && storedPlan.outlineExpansionMode === 'original-only';
   const originalPlan = hasOriginalPlan ? workspaceStore.readOriginalPlanMarkdown() : '';
@@ -706,12 +728,15 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
   } else {
     initialFiles = [
       { path: '响应文件要求.md', content: responseFileRequirements },
+      ...(standaloneTechnical ? [{ path: '技术评分信息.md', content: storedPlan.techRequirements || '' }] : []),
       { path: '项目概述.md', content: storedPlan.projectOverview || '' },
       ...(hasOriginalPlan ? [{ path: '原方案.md', content: originalPlan }] : []),
     ];
-    taskInstruction = hasOriginalPlan
-      ? '严格按照响应文件要求.md 组织一级目录，它是目录结构和标题来源的唯一依据。项目概述.md 仅用于理解背景和术语，不得据此新增一级目录；原方案.md 仅用于参考标题表达。'
-      : '严格按照响应文件要求.md 组织一级目录，它是目录结构和标题来源的唯一依据。项目概述.md 仅用于理解背景和术语，不得据此新增一级目录。';
+    taskInstruction = standaloneTechnical
+      ? '严格按照技术评分信息.md 中适合技术方案响应的评分大项组织一级目录，只生成技术方案独立分册。评分大项原文、顺序和数量是一级目录的权威依据；响应文件要求.md 只提供装订和响应约束，项目概述.md 仅用于理解背景和术语，原方案.md 仅用于参考下级标题表达。'
+      : hasOriginalPlan
+        ? '严格按照响应文件要求.md 组织一级目录，它是目录结构和标题来源的唯一依据。项目概述.md 仅用于理解背景和术语，不得据此新增一级目录；原方案.md 仅用于参考标题表达。'
+        : '严格按照响应文件要求.md 组织一级目录，它是目录结构和标题来源的唯一依据。项目概述.md 仅用于理解背景和术语，不得据此新增一级目录。';
   }
 
   let logs = restoringOutlineSelection
@@ -808,7 +833,7 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
     return {
       stage: 'children_generation',
       message: 'Agent 正在生成子目录',
-      prompt: createChildrenPrompt({ hasOriginalPlan, originalOnly, targetLeafCount, allowRootChanges }),
+      prompt: createChildrenPrompt({ hasOriginalPlan, originalOnly, targetLeafCount, allowRootChanges, standaloneTechnical }),
       files: [
         { path: OUTLINE_OUTPUT_FILE, content: JSON.stringify({ outline: lockedRoots }, null, 2) },
         {
@@ -856,7 +881,7 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
     const initialResult = await agentService.runTask({
       task_id: task.task_id,
       title: '技术方案一级目录生成',
-      prompt: createInitialPrompt(taskInstruction),
+      prompt: createInitialPrompt(taskInstruction, { standaloneTechnical }),
       output_file: OUTLINE_OUTPUT_FILE,
       files: initialFiles,
       signal: taskControl.signal,
@@ -887,7 +912,7 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
 
   const confirmed = await taskControl.waitForOutlineSelection();
   applyConfirmedSelection(confirmed);
-  const hasTenderWordOriginals = workspaceStore.listTenderSourceDocxRelativePaths().length > 0;
+  const hasTenderWordOriginals = !standaloneTechnical && workspaceStore.listTenderSourceDocxRelativePaths().length > 0;
   let initialStage;
   let initialStageIndex;
   let agentPrompt;
@@ -907,7 +932,7 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
   } else {
     initialStage = 'score-planning';
     initialStageIndex = 2;
-    agentPrompt = createScorePlanningPrompt({ templateExtractionSkipped: true });
+    agentPrompt = createScorePlanningPrompt({ templateExtractionSkipped: true, standaloneTechnical });
     agentFiles = [
       { path: OUTLINE_OUTPUT_FILE, content: JSON.stringify({ outline: lockedRoots }, null, 2) },
       { path: '技术评分信息.md', content: storedPlan.techRequirements || '' },
@@ -953,7 +978,7 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
           stage: 'score-planning',
           stage_index: 2,
           message: 'Agent 正在识别技术方案目录',
-          prompt: createScorePlanningPrompt(),
+          prompt: createScorePlanningPrompt({ standaloneTechnical }),
           files: [
             { path: OUTLINE_OUTPUT_FILE, content: JSON.stringify({ outline: lockedRoots }, null, 2) },
             { path: '技术评分信息.md', content: storedPlan.techRequirements || '' },
@@ -1128,4 +1153,7 @@ module.exports = {
   stripOutlineInternalFields,
   readJson,
   formatProgressTitle,
+  createInitialPrompt,
+  createScorePlanningPrompt,
+  createChildrenPrompt,
 };

--- a/client/electron/services/outlineGenerationTaskV2.cjs
+++ b/client/electron/services/outlineGenerationTaskV2.cjs
@@ -264,6 +264,11 @@ function deriveTargetLeafCount(options) {
   return null;
 }
 
+function enforceMinimumLeafTarget(targetLeafCount, fixedAiLeafCount, technicalBranchCount) {
+  if (targetLeafCount === null) return null;
+  return Math.max(targetLeafCount, fixedAiLeafCount + technicalBranchCount * 2);
+}
+
 // 统一目录层级编号，并按父子节点形态整理目录字段。
 function renumberOutline(items, prefix = '') {
   return (items || []).map((item, index) => {
@@ -709,7 +714,7 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
   const originalPlan = hasOriginalPlan ? workspaceStore.readOriginalPlanMarkdown() : '';
   const responseFileRequirements = storedPlan.bidAnalysisTasks?.responseFileRequirements?.content || '';
   const wordControlOptions = normalizeWordControlOptions(payload?.word_control_options || storedPlan.outlineWordControlOptions);
-  const targetLeafCount = deriveTargetLeafCount(wordControlOptions);
+  let targetLeafCount = deriveTargetLeafCount(wordControlOptions);
   const referenceDocumentIds = normalizeReferenceDocumentIds(storedPlan);
   const knowledgeFiles = buildKnowledgeFiles(knowledgeBaseService, referenceDocumentIds);
   const jsonValidationSchemas = {
@@ -1034,6 +1039,17 @@ async function runOutlineGenerationTaskV2({ agentService, workspaceStore, knowle
         allowRootChanges = scoreDirectoryPlan.allow_root_changes === true;
         fixedAiLeafCount = lockedRoots
           .filter((root) => !root.branch_id && root.content_mode === AI_CONTENT_MODE).length;
+        if (standaloneTechnical) {
+          const requestedLeafTarget = targetLeafCount;
+          targetLeafCount = enforceMinimumLeafTarget(
+            targetLeafCount,
+            fixedAiLeafCount,
+            technicalBranches.length,
+          );
+          if (requestedLeafTarget !== null && targetLeafCount !== requestedLeafTarget) {
+            publish(`独立成册目录至少需要 ${targetLeafCount} 个 AI 生成小节，已自动校正原目标 ${requestedLeafTarget}`, 50);
+          }
+        }
         allocatedAiLeafCount = targetLeafCount === null ? null : targetLeafCount - fixedAiLeafCount;
         if (allocatedAiLeafCount !== null && technicalBranches.length > 1) {
           publish('技术方案目录已确认，Agent 正在分配 AI 生成小节', 50);
@@ -1156,4 +1172,5 @@ module.exports = {
   createInitialPrompt,
   createScorePlanningPrompt,
   createChildrenPrompt,
+  enforceMinimumLeafTarget,
 };

--- a/client/electron/services/outlineGenerationTaskV2.cjs
+++ b/client/electron/services/outlineGenerationTaskV2.cjs
@@ -490,11 +490,11 @@ function buildKnowledgeFiles(knowledgeBaseService, documentIds) {
 
 function createInitialPrompt(taskInstruction, { standaloneTechnical = false } = {}) {
   const goal = standaloneTechnical
-    ? '我们的目标是为单独装订的技术方案准备一级目录。一级目录必须直接对应技术评分大项。'
+    ? '我们的目标是为单独装订的技术文件准备一级目录。一级目录必须直接对应技术评分大项。'
     : '我们的目标是为编写响应文件/投标文件准备一级目录。';
   const modeRequirements = standaloneTechnical
-    ? `6. 本模式只生成技术方案独立分册：只能保留适合展开技术正文的评分大项，attr 必须为“技术”，content_mode 必须为 ai-generate。
-7. 每个一级目录直接对应一个技术评分大项，并保持评分大项的原顺序和正式表述；不得创建“技术方案”“监理大纲”“监理大纲（暗标）”“施工组织设计”“技术标”等外层总目录，也不得加入商务、资信、投标函、授权委托书等非技术章节。
+    ? `6. 本模式只生成技术文件独立分册：只能保留适合展开技术正文的评分大项，attr 必须为“技术”，content_mode 必须为 ai-generate。
+7. 每个一级目录直接对应一个技术评分大项，并保持评分大项的原顺序和正式表述；不得创建“技术方案”“项目管理方案”“监理大纲”“监理大纲（暗标）”“施工组织设计”“技术标”等外层总目录，也不得加入商务、资信、投标函、授权委托书等非技术章节。
 8. 完整结构示例：{"outline":[{"id":"1","title":"评分大项一","description":"评分大项一的技术响应范围","attr":"技术","content_mode":"ai-generate"},{"id":"2","title":"评分大项二","description":"评分大项二的技术响应范围","attr":"技术","content_mode":"ai-generate"}]}。`
     : `6. 每个一级目录当前都是叶子节点，必须根据它后续应采用的内容处理方式填写 content_mode：技术方案正文使用 ai-generate；需要从招标文件提取并套用表格或格式的商务、资信材料使用 template-fill；需要在全部正文完成并确定 Word 页码后回填的点对点应答表使用 point-to-point；无法归类的特殊内容使用 other，并在 content_mode_note 说明原因。
 7. 完整结构示例：{"outline":[{"id":"1","title":"技术方案","description":"技术方案目录说明","attr":"技术","content_mode":"ai-generate"},{"id":"2","title":"特殊资料","description":"特殊资料目录说明","attr":"其他","content_mode":"other","content_mode_note":"说明特殊处理原因"}]}。content_mode_note 只在 content_mode=other 且确有说明时填写。`;
@@ -567,7 +567,7 @@ function createScorePlanningPrompt({ templateExtractionSkipped = false, standalo
     ? '程序已跳过投标模版提取，不要判断或补做该步骤，直接执行当前目录规划。'
     : '';
   const placementInstruction = standaloneTechnical
-    ? `4. 当前采用“技术方案独立成册”：${OUTLINE_OUTPUT_FILE} 中每个一级根节点本身就应对应一个技术评分大项。每个根节点建立一个 branch，score_item_level 固定为 1，mappings 只填写与该根标题对应的评分大项，target_title 必须与 root_title 完全一致；不得再创建“技术方案”“监理大纲”等外层分支。
+    ? `4. 当前采用“技术文件独立成册”：${OUTLINE_OUTPUT_FILE} 中每个一级根节点本身就应对应一个技术评分大项。每个根节点建立一个 branch，score_item_level 固定为 1，mappings 只填写与该根标题对应的评分大项，target_title 必须与 root_title 完全一致；不得再创建“技术方案”“项目管理方案”“监理大纲”“监理大纲（暗标）”“施工组织设计”“技术标”等外层分支。
 5. 一级根节点与评分大项默认严格一一对应；发现缺失、重复、合并或顺序不一致时，必须作为一级目录调整向用户说明并取得批准。detail_points 只用于后续生成根节点以下的目录。`
     : `4. 判断技术方案位于哪些目录分支，以及每个分支内评分项对应节点应统一处于哪个层级。不同分支可以使用不同层级，不预设必须是二级目录。优先选择 attr=技术且 content_mode=ai-generate 的一级目录；template-fill、point-to-point 和 other 是特殊处理叶子，不得作为普通技术方案分支展开，除非先向用户说明并取得调整批准。
 5. 默认每个评分项对应一个独立同层级节点，节点标题与评分大项基本一一对应；detail_points 用于后续生成更下级目录。`;

--- a/client/electron/services/outlineGenerationTaskV2.test.cjs
+++ b/client/electron/services/outlineGenerationTaskV2.test.cjs
@@ -11,7 +11,7 @@ test('独立成册模式直接以技术评分大项作为一级目录', () => {
   const prompt = createInitialPrompt('按响应文件要求生成。', { standaloneTechnical: true });
 
   assert.match(prompt, /一级目录必须直接对应技术评分大项/);
-  assert.match(prompt, /不得创建“技术方案”“监理大纲”/);
+  assert.match(prompt, /不得创建“技术方案”“项目管理方案”“监理大纲”“监理大纲（暗标）”“施工组织设计”“技术标”/);
   assert.match(prompt, /不得加入商务、资信、投标函、授权委托书/);
 });
 
@@ -20,6 +20,7 @@ test('独立成册评分规划把根节点固定为评分项层级', () => {
 
   assert.match(prompt, /score_item_level 固定为 1/);
   assert.match(prompt, /target_title 必须与 root_title 完全一致/);
+  assert.match(prompt, /不得再创建“技术方案”“项目管理方案”“监理大纲”“监理大纲（暗标）”“施工组织设计”“技术标”/);
 });
 
 test('独立成册生成子目录时不重复评分项根标题', () => {

--- a/client/electron/services/outlineGenerationTaskV2.test.cjs
+++ b/client/electron/services/outlineGenerationTaskV2.test.cjs
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  createInitialPrompt,
+  createScorePlanningPrompt,
+  createChildrenPrompt,
+} = require('./outlineGenerationTaskV2.cjs');
+
+test('独立成册模式直接以技术评分大项作为一级目录', () => {
+  const prompt = createInitialPrompt('按响应文件要求生成。', { standaloneTechnical: true });
+
+  assert.match(prompt, /一级目录必须直接对应技术评分大项/);
+  assert.match(prompt, /不得创建“技术方案”“监理大纲”/);
+  assert.match(prompt, /不得加入商务、资信、投标函、授权委托书/);
+});
+
+test('独立成册评分规划把根节点固定为评分项层级', () => {
+  const prompt = createScorePlanningPrompt({ standaloneTechnical: true });
+
+  assert.match(prompt, /score_item_level 固定为 1/);
+  assert.match(prompt, /target_title 必须与 root_title 完全一致/);
+});
+
+test('独立成册生成子目录时不重复评分项根标题', () => {
+  const prompt = createChildrenPrompt({
+    hasOriginalPlan: false,
+    originalOnly: false,
+    targetLeafCount: 10,
+    allowRootChanges: false,
+    standaloneTechnical: true,
+  });
+
+  assert.match(prompt, /现有一级根节点本身就是评分项映射节点/);
+  assert.match(prompt, /不得在根节点下面再次生成同名评分项/);
+  assert.doesNotMatch(prompt, /"title":"技术方案"/);
+});

--- a/client/electron/services/outlineGenerationTaskV2.test.cjs
+++ b/client/electron/services/outlineGenerationTaskV2.test.cjs
@@ -5,6 +5,7 @@ const {
   createInitialPrompt,
   createScorePlanningPrompt,
   createChildrenPrompt,
+  enforceMinimumLeafTarget,
 } = require('./outlineGenerationTaskV2.cjs');
 
 test('独立成册模式直接以技术评分大项作为一级目录', () => {
@@ -35,4 +36,11 @@ test('独立成册生成子目录时不重复评分项根标题', () => {
   assert.match(prompt, /现有一级根节点本身就是评分项映射节点/);
   assert.match(prompt, /不得在根节点下面再次生成同名评分项/);
   assert.doesNotMatch(prompt, /"title":"技术方案"/);
+});
+
+test('独立成册末级小节目标满足每个技术分支至少两个', () => {
+  assert.equal(enforceMinimumLeafTarget(10, 0, 6), 12);
+  assert.equal(enforceMinimumLeafTarget(14, 0, 6), 14);
+  assert.equal(enforceMinimumLeafTarget(10, 2, 5), 12);
+  assert.equal(enforceMinimumLeafTarget(null, 0, 6), null);
 });

--- a/client/electron/services/taskService.cjs
+++ b/client/electron/services/taskService.cjs
@@ -1368,7 +1368,11 @@ function createTaskService({ aiService, agentService, autoConfirmationService, t
       return startManagedTask('bid-analysis', payload, runBidAnalysisTask);
     },
     startOutlineGeneration(payload) {
-      const outlineMode = payload?.outline_mode === 'response-file' ? 'response-file' : 'aligned';
+      const outlineMode = payload?.outline_mode === 'standalone-technical'
+        ? 'standalone-technical'
+        : payload?.outline_mode === 'response-file'
+          ? 'response-file'
+          : 'aligned';
       const taskPayload = { ...payload, outline_mode: outlineMode };
       return startManagedTask('outline-generation', taskPayload, runOutlineGenerationTaskV2, {
         outlineMode,

--- a/client/electron/services/technicalPlanStore.cjs
+++ b/client/electron/services/technicalPlanStore.cjs
@@ -313,7 +313,7 @@ function getBidAnalysisTaskIdsForConfig(mode, selectedTaskIds) {
 }
 
 function isValidOutlineMode(value) {
-  return value === 'aligned' || value === 'response-file';
+  return value === 'aligned' || value === 'response-file' || value === 'standalone-technical';
 }
 
 function isValidOutlineExpansionMode(value) {

--- a/client/src/features/technical-plan/pages/OutlineEditPage.tsx
+++ b/client/src/features/technical-plan/pages/OutlineEditPage.tsx
@@ -439,6 +439,7 @@ function OutlineEditPage({
     strictSectionWords: parsedDraftSectionWords > 0 && draftStrictSectionWords,
   };
   const wordControlRequiresRegeneration = Boolean(outlineData && !areWordControlOptionsEqual(normalizedDraftOptions, outlineWordControlSnapshot));
+  const outlineModeRequiresRegeneration = Boolean(outlineData && !isExpansionWorkflow && draftOutlineMode !== outlineMode);
 
   const initializeWordControlDraft = () => {
     setDraftMinimumWords(formatWordCountDraft(outlineWordControlOptions.minimumWords));
@@ -577,6 +578,10 @@ function OutlineEditPage({
   };
 
   const saveOutlineConfig = async () => {
+    if (outlineModeRequiresRegeneration) {
+      showToast('技术文件结构已改变，请点击“重新生成目录”使新结构生效', 'info');
+      return;
+    }
     try {
       const wordControlOptions = getNormalizedWordControlOptions();
       setSavingOutlineConfig(true);
@@ -1084,6 +1089,11 @@ function OutlineEditPage({
             );
           })}
         </div>
+        {outlineModeRequiresRegeneration && (
+          <div className="outline-word-control-notice">
+            技术文件结构已改变，需要重新生成目录后才能生效！
+          </div>
+        )}
       </section>
     );
   };

--- a/client/src/features/technical-plan/pages/OutlineEditPage.tsx
+++ b/client/src/features/technical-plan/pages/OutlineEditPage.tsx
@@ -77,12 +77,12 @@ const technicalDocumentModeOptions: Array<{ value: Extract<OutlineMode, 'respons
   {
     value: 'response-file',
     title: '完整投标文件结构',
-    description: '保留技术方案或监理大纲等外层章节，便于后续继续组织商务、资信等完整投标文件。',
+    description: '保留技术方案、项目管理方案、监理大纲、施工组织设计或技术标等外层章节，便于组织完整投标文件。',
   },
   {
     value: 'standalone-technical',
-    title: '技术方案独立成册',
-    description: '一级目录直接从技术评分大项开始，不再创建技术方案、监理大纲等外层总目录。',
+    title: '技术文件独立成册',
+    description: '一级目录直接从技术评分大项开始，不再创建技术方案、项目管理方案、监理大纲、施工组织设计或技术标等外层总目录。',
   },
 ];
 

--- a/client/src/features/technical-plan/pages/OutlineEditPage.tsx
+++ b/client/src/features/technical-plan/pages/OutlineEditPage.tsx
@@ -15,6 +15,7 @@ import OutlineSelectionDialog from '../components/OutlineSelectionDialog';
 interface OutlineEditPageProps {
   workflowKind: TechnicalPlanWorkflowKind;
   projectOverview: string;
+  outlineMode: OutlineMode;
   outlineExpansionMode: OutlineExpansionMode;
   outlineWordControlOptions: OutlineWordControlOptions;
   outlineWordControlSnapshot?: OutlineWordControlOptions;
@@ -70,6 +71,18 @@ const outlineExpansionModeOptions: Array<{ value: OutlineExpansionMode; title: s
     value: 'ai-complement',
     title: outlineExpansionModeLabels['ai-complement'],
     description: '保留原方案一级目录，在其基础上补充招标评分项缺口，并可继续使用知识库增强。',
+  },
+];
+const technicalDocumentModeOptions: Array<{ value: Extract<OutlineMode, 'response-file' | 'standalone-technical'>; title: string; description: string }> = [
+  {
+    value: 'response-file',
+    title: '完整投标文件结构',
+    description: '保留技术方案或监理大纲等外层章节，便于后续继续组织商务、资信等完整投标文件。',
+  },
+  {
+    value: 'standalone-technical',
+    title: '技术方案独立成册',
+    description: '一级目录直接从技术评分大项开始，不再创建技术方案、监理大纲等外层总目录。',
   },
 ];
 
@@ -323,6 +336,7 @@ function includesKeyword(value: string, keyword: string) {
 function OutlineEditPage({
   workflowKind,
   projectOverview,
+  outlineMode,
   outlineExpansionMode,
   outlineWordControlOptions,
   outlineWordControlSnapshot,
@@ -348,6 +362,7 @@ function OutlineEditPage({
   const [startingOutline, setStartingOutline] = useState(false);
   const [progressCollapsed, setProgressCollapsed] = useState(false);
   const [generationDialogOpen, setGenerationDialogOpen] = useState(false);
+  const [draftOutlineMode, setDraftOutlineMode] = useState<OutlineMode>(outlineMode === 'standalone-technical' ? 'standalone-technical' : 'response-file');
   const [draftOutlineExpansionMode, setDraftOutlineExpansionMode] = useState<OutlineExpansionMode>(outlineExpansionMode);
   const [draftKnowledgeDocumentIds, setDraftKnowledgeDocumentIds] = useState<string[]>(referenceKnowledgeDocumentIds);
   const [draftMinimumWords, setDraftMinimumWords] = useState(formatWordCountDraft(outlineWordControlOptions.minimumWords));
@@ -501,12 +516,13 @@ function OutlineEditPage({
       return;
     }
 
+    setDraftOutlineMode(outlineMode === 'standalone-technical' ? 'standalone-technical' : 'response-file');
     setDraftOutlineExpansionMode(isExpansionWorkflow ? outlineExpansionMode : 'ai-complement');
     setDraftKnowledgeDocumentIds(referenceKnowledgeDocumentIds);
     initializeWordControlDraft();
     setKnowledgeSearch('');
     void loadKnowledgeIndex();
-  }, [generationDialogOpen, isExpansionWorkflow, outlineExpansionMode, outlineWordControlOptions, referenceKnowledgeDocumentIds]);
+  }, [generationDialogOpen, isExpansionWorkflow, outlineMode, outlineExpansionMode, outlineWordControlOptions, referenceKnowledgeDocumentIds]);
 
   const loadKnowledgeIndex = async () => {
     try {
@@ -538,6 +554,7 @@ function OutlineEditPage({
       return;
     }
 
+    setDraftOutlineMode(outlineMode === 'standalone-technical' ? 'standalone-technical' : 'response-file');
     setDraftOutlineExpansionMode(isExpansionWorkflow ? outlineExpansionMode : 'ai-complement');
     setDraftKnowledgeDocumentIds(referenceKnowledgeDocumentIds);
     initializeWordControlDraft();
@@ -565,7 +582,7 @@ function OutlineEditPage({
       setSavingOutlineConfig(true);
       await onOutlineConfigChange({
         referenceKnowledgeDocumentIds: draftKnowledgeDocumentIds,
-        outlineMode: isExpansionWorkflow ? 'aligned' : 'response-file',
+        outlineMode: isExpansionWorkflow ? 'aligned' : draftOutlineMode,
         outlineExpansionMode: isExpansionWorkflow ? draftOutlineExpansionMode : 'ai-complement',
         wordControlOptions,
       });
@@ -595,7 +612,7 @@ function OutlineEditPage({
       setStartingOutline(true);
       setLocalStartAt(startedNow);
       setNowTick(startedNow);
-      const nextOutlineMode: OutlineMode = isExpansionWorkflow ? 'aligned' : 'response-file';
+      const nextOutlineMode: OutlineMode = isExpansionWorkflow ? 'aligned' : draftOutlineMode;
       const nextOutlineExpansionMode = isExpansionWorkflow ? draftOutlineExpansionMode : 'ai-complement';
       await onOutlineConfigChange({
         referenceKnowledgeDocumentIds: draftKnowledgeDocumentIds,
@@ -1071,6 +1088,39 @@ function OutlineEditPage({
     );
   };
 
+  const renderTechnicalDocumentModePicker = () => {
+    if (isExpansionWorkflow) {
+      return null;
+    }
+
+    return (
+      <section className="outline-generation-config-section outline-expansion-mode-section">
+        <div className="outline-generation-config-head">
+          <strong>技术文件结构</strong>
+          <span>{technicalDocumentModeOptions.find((option) => option.value === draftOutlineMode)?.title}</span>
+        </div>
+        <div className="outline-expansion-mode-switch">
+          {technicalDocumentModeOptions.map((option) => {
+            const selected = draftOutlineMode === option.value;
+            return (
+              <button
+                type="button"
+                className={`outline-expansion-mode-option${selected ? ' is-selected' : ''}`}
+                key={option.value}
+                onClick={() => setDraftOutlineMode(option.value)}
+                disabled={generating}
+                aria-pressed={selected}
+              >
+                <strong>{option.title}</strong>
+                <span>{option.description}</span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+    );
+  };
+
   const renderKnowledgePicker = () => {
     if (loadingKnowledge) {
       return <div className="outline-knowledge-empty">正在读取知识库...</div>;
@@ -1186,7 +1236,7 @@ function OutlineEditPage({
         <div>
           <span className="section-kicker">STEP 03</span>
           <strong>目录生成</strong>
-          <p>{isExpansionWorkflow ? `当前原方案目录使用方式：${outlineExpansionModeLabels[outlineExpansionMode]}；参考知识库：${referenceKnowledgeDocumentIds.length ? `已选择 ${referenceKnowledgeDocumentIds.length} 个文档` : '未选择'}。` : `一级目录依据响应文件要求生成；参考知识库：${referenceKnowledgeDocumentIds.length ? `已选择 ${referenceKnowledgeDocumentIds.length} 个文档` : '未选择'}。`}</p>
+          <p>{isExpansionWorkflow ? `当前原方案目录使用方式：${outlineExpansionModeLabels[outlineExpansionMode]}；参考知识库：${referenceKnowledgeDocumentIds.length ? `已选择 ${referenceKnowledgeDocumentIds.length} 个文档` : '未选择'}。` : `${outlineMode === 'standalone-technical' ? '技术评分大项直接作为一级目录' : '一级目录依据完整响应文件要求生成'}；参考知识库：${referenceKnowledgeDocumentIds.length ? `已选择 ${referenceKnowledgeDocumentIds.length} 个文档` : '未选择'}。`}</p>
         </div>
         <div className="outline-command-actions">
           {awaitingOutlineSelection && (
@@ -1394,6 +1444,7 @@ function OutlineEditPage({
             <div className="outline-generation-config-body">
               {/* 左栏：所有配置项 */}
               <div className="outline-generation-config-left">
+                {renderTechnicalDocumentModePicker()}
                 {renderOutlineExpansionModePicker()}
                 <section className="outline-generation-config-section outline-word-control-section">
                   <div className="content-generation-config-row">

--- a/client/src/features/technical-plan/pages/TechnicalPlanHome.tsx
+++ b/client/src/features/technical-plan/pages/TechnicalPlanHome.tsx
@@ -1336,6 +1336,7 @@ function TechnicalPlanHome({ workflowKind, registerLeaveGuard, onSectionChange }
           <OutlineEditPage
             workflowKind={workflowKind}
             projectOverview={state.projectOverview}
+            outlineMode={state.outlineMode}
             outlineExpansionMode={state.outlineExpansionMode || 'ai-complement'}
           outlineWordControlOptions={state.outlineWordControlOptions}
           outlineWordControlSnapshot={state.outlineWordControlSnapshot}

--- a/client/src/shared/types/outline.ts
+++ b/client/src/shared/types/outline.ts
@@ -21,7 +21,7 @@ export interface OutlineItem {
   content?: string;
 }
 
-export type OutlineMode = 'aligned' | 'response-file';
+export type OutlineMode = 'aligned' | 'response-file' | 'standalone-technical';
 export type OutlineExpansionMode = 'original-only' | 'ai-complement';
 
 export interface OutlineWordControlOptions {


### PR DESCRIPTION
## 修改内容
- 在目录生成配置中新增“技术文件独立成册”模式，保留现有完整投标文件结构作为默认流程。
- 独立成册模式直接读取技术评分信息，以技术评分大项作为一级根目录。
- 禁止再次套用“技术方案”“项目管理方案”“监理大纲”“施工组织设计”“技术标”等外层总章。
- 评分规划固定根节点为评分项映射层，子目录生成不得重复评分项根标题。
- 独立成册模式跳过完整响应文件模板章节提取，避免把外层投标文件结构重新带回目录。
- 增加模式持久化、任务透传和提示词单元测试。

## 解决的问题
当前目录生成面向完整投标文件。技术文件需要独立装订时，系统仍可能创建“监理大纲（暗标）”“施工组织设计”等总章，导致技术评分项整体下沉一级。本模式让技术评分项直接从一级目录开始，同时不改变现有默认完整投标文件流程。

## 测试方式
- `node --check client/electron/services/outlineGenerationTaskV2.cjs`
- `node --test client/electron/services/outlineGenerationTaskV2.test.cjs`
- TypeScript `--noEmit` 检查通过
- Vite 生产构建通过
- Windows 便携测试版完成实际流程验证