### PR TITLE
feat: 新增 ComfyUI 生图提供方（服务端工作流自动探测）

### DIFF
--- a/client/electron/services/aiService.cjs
+++ b/client/electron/services/aiService.cjs
@@ -157,8 +157,9 @@ function normalizeImageRequestMode(imageConfig) {
 }
 
 function normalizeOpenAICompatibleImageSize(imageConfig, requestSize) {
-  const size = String(requestSize || imageConfig?.image_size || '1024x1024').trim();
-  return size || '1024x1024';
+  const requested = String(requestSize || '').trim();
+  const configured = String(imageConfig?.image_size || '').trim();
+  return requested || configured || '1024x1024';
 }
 
 function normalizeGoogleImageSize(imageConfig) {
@@ -1781,22 +1782,38 @@ function sleepMs(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const COMFYUI_MIN_IMAGE_DIMENSION = 64;
+const COMFYUI_MAX_IMAGE_DIMENSION = 8192;
+
+function isValidComfyUIDimension(value) {
+  return Number.isInteger(value)
+    && value >= COMFYUI_MIN_IMAGE_DIMENSION
+    && value <= COMFYUI_MAX_IMAGE_DIMENSION
+    && value % 8 === 0;
+}
+
 function resolveComfyUIImageSize(imageConfig, requestSize) {
-  const raw = String(requestSize || imageConfig?.image_size || '1024x1024').trim();
-  const direct = raw.match(/^(\d{3,5})x(\d{3,5})$/i);
+  const fallback = String(imageConfig?.image_size || '').trim() || '1024x1024';
+  const requested = String(requestSize || '').trim();
+  // 归一化常见写法：中文乘号 × / ✕、大写 X、内部空白
+  const raw = (requested || fallback).replace(/[×✕X]/g, 'x').replace(/\s+/g, '');
+  const direct = raw.match(/^(\d{1,5})x(\d{1,5})$/i);
   if (direct) {
-    return { width: Number(direct[1]), height: Number(direct[2]) };
+    const width = Number(direct[1]);
+    const height = Number(direct[2]);
+    if (isValidComfyUIDimension(width) && isValidComfyUIDimension(height)) {
+      return { width, height };
+    }
   }
-  switch (raw) {
+  switch (raw.toLowerCase()) {
     case '512':
       return { width: 512, height: 512 };
-    case '2K':
+    case '2k':
       return { width: 2048, height: 2048 };
-    case '4K':
-      return { width: 3840, height: 2160 };
-    case 'auto':
-    case '1K':
+    case '4k':
+      return { width: 4096, height: 4096 };
     default:
+      // 'auto' / '1K' / 无法识别的写法统一回退默认方图
       return { width: 1024, height: 1024 };
   }
 }
@@ -1814,6 +1831,10 @@ function parseComfyUIWorkflowJson(raw) {
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
     throw new Error('ComfyUI 工作流格式不正确，请粘贴 API 格式（Save API Format）导出的 JSON');
+  }
+  const hasNode = Object.values(parsed).some((node) => node && typeof node === 'object' && typeof node.class_type === 'string');
+  if (!hasNode) {
+    throw new Error('ComfyUI 工作流内容为空或不包含有效节点，请粘贴 API 格式（Save API Format）导出的 JSON');
   }
   return parsed;
 }
@@ -1846,15 +1867,35 @@ function extractComfyUIHistoryWorkflow(promptTuple) {
   return null;
 }
 
+// 从执行消息中取时间戳（execution_start/execution_success），用于排序
+function getComfyUIHistoryEntryTimestamp(entry) {
+  const messages = Array.isArray(entry?.status?.messages) ? entry.status.messages : [];
+  let timestamp = 0;
+  for (const message of messages) {
+    if (Array.isArray(message) && (message[0] === 'execution_start' || message[0] === 'execution_success')) {
+      const value = Number(message[1]?.timestamp);
+      if (Number.isFinite(value) && value > timestamp) timestamp = value;
+    }
+  }
+  return timestamp;
+}
+
 // 从 /history 中挑出最近一次成功执行的文生图工作流
 function pickComfyUIHistoryWorkflow(historyData) {
   if (!historyData || typeof historyData !== 'object') return null;
   let picked = null;
+  let pickedRank = -1;
+  let index = 0;
   for (const entry of Object.values(historyData)) {
+    index += 1;
     if (entry?.status?.status_str !== 'success') continue;
     const workflow = extractComfyUIHistoryWorkflow(entry?.prompt);
-    if (isComfyUITextToImageWorkflow(workflow)) {
+    if (!isComfyUITextToImageWorkflow(workflow)) continue;
+    // 优先按执行时间戳取最新；时间戳缺失时退化为遍历顺序（>= 保证取到更靠后的条目）
+    const rank = getComfyUIHistoryEntryTimestamp(entry) || index;
+    if (rank >= pickedRank) {
       picked = workflow;
+      pickedRank = rank;
     }
   }
   return picked;
@@ -1878,9 +1919,11 @@ async function fetchComfyUIJson(baseUrl, path, options = {}) {
 // 服务器装有 checkpoint 模型时，按标准结构组装一个最简文生图工作流
 function buildComfyUICheckpointWorkflow(objectInfo) {
   const checkpoints = objectInfo?.CheckpointLoaderSimple?.input?.required?.ckpt_name?.[0];
-  if (!Array.isArray(checkpoints) || checkpoints.length === 0) return null;
+  if (!Array.isArray(checkpoints)) return null;
+  const checkpointName = checkpoints.find((name) => typeof name === 'string' && name.trim());
+  if (!checkpointName) return null;
   return {
-    '1': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: checkpoints[0] } },
+    '1': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: checkpointName } },
     '2': { class_type: 'CLIPTextEncode', inputs: { text: '', clip: ['1', 1] } },
     '3': { class_type: 'CLIPTextEncode', inputs: { text: '', clip: ['1', 1] } },
     '4': { class_type: 'EmptyLatentImage', inputs: { width: 1024, height: 1024, batch_size: 1 } },
@@ -1894,7 +1937,11 @@ function buildComfyUICheckpointWorkflow(objectInfo) {
 async function resolveComfyUIWorkflowTemplate(baseUrl, imageConfig, options = {}) {
   const raw = String(imageConfig?.comfyui_workflow || '').trim();
   if (raw) {
-    return { workflow: parseComfyUIWorkflowJson(raw), source: 'custom' };
+    const customWorkflow = parseComfyUIWorkflowJson(raw);
+    if (!isComfyUITextToImageWorkflow(customWorkflow)) {
+      throw new Error('设置中粘贴的工作流不是完整的文生图工作流：需要包含 KSampler、CLIPTextEncode 与 Empty Latent 节点（当前仅支持文生图，img2img 等工作流暂不支持）');
+    }
+    return { workflow: customWorkflow, source: 'custom' };
   }
   const historyData = await fetchComfyUIJson(baseUrl, '/history?max_items=50', options);
   const historyWorkflow = pickComfyUIHistoryWorkflow(historyData);
@@ -1914,6 +1961,10 @@ function buildComfyUIImageWorkflow(baseWorkflow, prompt, size) {
   if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) {
     throw new Error('ComfyUI 工作流格式不正确');
   }
+  const normalizedPrompt = String(prompt || '').trim();
+  if (!normalizedPrompt) {
+    throw new Error('生图提示词为空，请检查输入内容');
+  }
 
   const nodes = Object.entries(workflow);
   let samplerNode = null;
@@ -1926,40 +1977,38 @@ function buildComfyUIImageWorkflow(baseWorkflow, prompt, size) {
     if (node.class_type === 'SaveImage') saveNode = saveNode || node;
   }
 
-  // 正向提示词写入采样器 positive 指向的文本节点；找不到就退而取第一个文本节点
+  // 正向提示词写入采样器 positive 指向的文本节点。
+  // 兜底时必须排除采样器 negative 指向的节点，否则提示词会被写进负向节点（效果完全相反）
   let promptNode = null;
   const positiveRef = samplerNode?.inputs?.positive;
   if (Array.isArray(positiveRef) && workflow[positiveRef[0]]?.class_type === 'CLIPTextEncode') {
     promptNode = workflow[positiveRef[0]];
   }
   if (!promptNode) {
-    for (const [, node] of nodes) {
-      if (node?.class_type === 'CLIPTextEncode' && String(node.inputs?.text || '').trim()) {
-        promptNode = node;
-        break;
+    const negativeRef = samplerNode?.inputs?.negative;
+    const negativeNodeId = Array.isArray(negativeRef) ? String(negativeRef[0]) : null;
+    const candidates = [];
+    for (const [nodeId, node] of nodes) {
+      if (node?.class_type === 'CLIPTextEncode' && nodeId !== negativeNodeId) {
+        candidates.push(node);
       }
     }
+    // 典型工作流里正向节点留空待注入、负向节点预填词，优先选空文本节点
+    promptNode = candidates.find((node) => !String(node.inputs?.text || '').trim()) || candidates[0] || null;
   }
   if (!promptNode) {
-    for (const [, node] of nodes) {
-      if (node?.class_type === 'CLIPTextEncode') {
-        promptNode = node;
-        break;
-      }
-    }
+    throw new Error('ComfyUI 工作流中没有可用的 CLIPTextEncode 正向提示词节点（positive 连接无效，且负向节点之外没有其他文本节点），请检查工作流连接');
   }
-  if (!promptNode) {
-    throw new Error('ComfyUI 工作流中没有 CLIPTextEncode 节点，无法注入提示词');
-  }
-  promptNode.inputs = { ...promptNode.inputs, text: prompt };
+  promptNode.inputs = { ...promptNode.inputs, text: normalizedPrompt };
 
   if (latentNode) {
     latentNode.inputs = { ...latentNode.inputs, width: size.width, height: size.height };
   }
 
-  if (samplerNode?.inputs && Object.prototype.hasOwnProperty.call(samplerNode.inputs, 'seed')) {
+  // seed 为节点链接（数组）时保持原样，不能用随机数覆盖断链
+  if (typeof samplerNode?.inputs?.seed === 'number') {
     samplerNode.inputs = { ...samplerNode.inputs, seed: crypto.randomInt(0, 4294967296) };
-  } else if (samplerNode?.inputs && Object.prototype.hasOwnProperty.call(samplerNode.inputs, 'noise_seed')) {
+  } else if (typeof samplerNode?.inputs?.noise_seed === 'number') {
     samplerNode.inputs = { ...samplerNode.inputs, noise_seed: crypto.randomInt(0, 4294967296) };
   }
 
@@ -1980,13 +2029,14 @@ async function submitComfyUIPrompt(baseUrl, workflow, options = {}) {
       signal: options.signal,
     });
   } catch (error) {
-    throw markAiRequestError(error, { retryable: true });
+    // 提交非幂等：网络错误时任务可能已入队，重试会导致同一提示词重复排队
+    throw markAiRequestError(error, { retryable: false });
   }
   await ensureOk(response, 'ComfyUI 任务提交失败', { source: options.source || 'comfyui-image-model' });
   try {
     return await response.json();
   } catch (error) {
-    throw markAiRequestError(error, { retryable: true });
+    throw markAiRequestError(error, { retryable: false });
   }
 }
 
@@ -2034,12 +2084,14 @@ async function waitComfyUIImageResult(baseUrl, promptId, options = {}) {
             if (images.length > 0) {
               return { entry, images };
             }
+            // 已到终态但没有图片输出（典型原因：工作流缺少 SaveImage 节点），继续轮询不会有变化
+            throw createAiResponseDataError('ComfyUI 任务已完成但没有产出图片，请检查工作流是否包含 SaveImage 等图片输出节点', entry.status);
           }
         }
       }
     } catch (error) {
       if (options.signal?.aborted || error?.name === 'AbortError') throw error;
-      if (error?.response_data) throw error;
+      if (error?.raw_response_data) throw error;
       // 轮询期间的瞬时网络错误不致命，继续等待
     }
     await sleepMs(COMFYUI_POLL_INTERVAL_MS);
@@ -2069,7 +2121,8 @@ async function fetchComfyUIImage(baseUrl, image, options = {}) {
 async function runComfyUIImageGeneration(app, config, request, options = {}) {
   const imageConfig = config.image_model || {};
   const baseUrl = requireBaseUrl(imageConfig.base_url, 'ComfyUI 服务地址缺失，请在设置中填写后保存配置');
-  const prompt = options.promptOverride || normalizeImagePrompt(request);
+  const overridePrompt = String(options.promptOverride || '').trim();
+  const prompt = overridePrompt || normalizeImagePrompt(request);
   const size = options.sizeOverride || resolveComfyUIImageSize(imageConfig, request.size);
   const requestId = createRequestId();
   const logTitle = resolveAiLogTitle(request, request.title ? `AI生图-${request.title}` : 'AI生图');

--- a/client/electron/services/aiService.cjs
+++ b/client/electron/services/aiService.cjs
@@ -269,6 +269,13 @@ function getImageModelAvailability(config) {
     return { available: false, status: imageConfig.status || 'untested', message: '生图模型未测试可用' };
   }
 
+  if (imageConfig.provider === 'comfyui') {
+    if (!trimBaseUrl(imageConfig.base_url)) {
+      return { available: false, status: 'unavailable', message: '请先填写 ComfyUI 服务地址' };
+    }
+    return { available: true, status: 'available', message: '生图模型可用' };
+  }
+
   if (!imageConfig.api_key) {
     return { available: false, status: 'unavailable', message: '请先填写生图模型 API Key' };
   }
@@ -1768,6 +1775,422 @@ async function generateGoogleImage(app, config, request) {
   }
 }
 
+const COMFYUI_POLL_INTERVAL_MS = 2000;
+
+function sleepMs(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function resolveComfyUIImageSize(imageConfig, requestSize) {
+  const raw = String(requestSize || imageConfig?.image_size || '1024x1024').trim();
+  const direct = raw.match(/^(\d{3,5})x(\d{3,5})$/i);
+  if (direct) {
+    return { width: Number(direct[1]), height: Number(direct[2]) };
+  }
+  switch (raw) {
+    case '512':
+      return { width: 512, height: 512 };
+    case '2K':
+      return { width: 2048, height: 2048 };
+    case '4K':
+      return { width: 3840, height: 2160 };
+    case 'auto':
+    case '1K':
+    default:
+      return { width: 1024, height: 1024 };
+  }
+}
+
+function parseComfyUIWorkflowJson(raw) {
+  let parsed = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error('ComfyUI 工作流 JSON 解析失败，请检查设置中粘贴的工作流内容');
+  }
+  // 兼容带 prompt 外层包装的导出内容
+  if (parsed && typeof parsed === 'object' && parsed.prompt && typeof parsed.prompt === 'object') {
+    parsed = parsed.prompt;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('ComfyUI 工作流格式不正确，请粘贴 API 格式（Save API Format）导出的 JSON');
+  }
+  return parsed;
+}
+
+function isComfyUITextToImageWorkflow(workflow) {
+  if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) return false;
+  let hasSampler = false;
+  let hasTextEncode = false;
+  let hasLatent = false;
+  for (const node of Object.values(workflow)) {
+    if (!node || typeof node !== 'object') continue;
+    if (node.class_type === 'KSampler' || node.class_type === 'KSamplerAdvanced') hasSampler = true;
+    if (node.class_type === 'CLIPTextEncode') hasTextEncode = true;
+    if (node.class_type === 'EmptySD3LatentImage' || node.class_type === 'EmptyLatentImage') hasLatent = true;
+  }
+  return hasSampler && hasTextEncode && hasLatent;
+}
+
+// 历史条目的 prompt 元组在不同版本里布局不同（[prio, workflow, ...] 或 [prio, id, workflow, ...]），
+// 取第一个"值为节点对象"的元素即为工作流
+function extractComfyUIHistoryWorkflow(promptTuple) {
+  if (!Array.isArray(promptTuple)) return null;
+  for (const item of promptTuple) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const values = Object.values(item);
+    if (values.length > 0 && values.some((node) => node && typeof node === 'object' && typeof node.class_type === 'string')) {
+      return item;
+    }
+  }
+  return null;
+}
+
+// 从 /history 中挑出最近一次成功执行的文生图工作流
+function pickComfyUIHistoryWorkflow(historyData) {
+  if (!historyData || typeof historyData !== 'object') return null;
+  let picked = null;
+  for (const entry of Object.values(historyData)) {
+    if (entry?.status?.status_str !== 'success') continue;
+    const workflow = extractComfyUIHistoryWorkflow(entry?.prompt);
+    if (isComfyUITextToImageWorkflow(workflow)) {
+      picked = workflow;
+    }
+  }
+  return picked;
+}
+
+async function fetchComfyUIJson(baseUrl, path, options = {}) {
+  let response = null;
+  try {
+    response = await fetch(`${baseUrl}${path}`, { signal: options.signal });
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+// 服务器装有 checkpoint 模型时，按标准结构组装一个最简文生图工作流
+function buildComfyUICheckpointWorkflow(objectInfo) {
+  const checkpoints = objectInfo?.CheckpointLoaderSimple?.input?.required?.ckpt_name?.[0];
+  if (!Array.isArray(checkpoints) || checkpoints.length === 0) return null;
+  return {
+    '1': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: checkpoints[0] } },
+    '2': { class_type: 'CLIPTextEncode', inputs: { text: '', clip: ['1', 1] } },
+    '3': { class_type: 'CLIPTextEncode', inputs: { text: '', clip: ['1', 1] } },
+    '4': { class_type: 'EmptyLatentImage', inputs: { width: 1024, height: 1024, batch_size: 1 } },
+    '5': { class_type: 'KSampler', inputs: { model: ['1', 0], positive: ['2', 0], negative: ['3', 0], latent_image: ['4', 0], seed: 0, steps: 20, cfg: 7.0, sampler_name: 'euler', scheduler: 'normal', denoise: 1.0 } },
+    '6': { class_type: 'VAEDecode', inputs: { samples: ['5', 0], vae: ['1', 2] } },
+    '7': { class_type: 'SaveImage', inputs: { images: ['6', 0], filename_prefix: 'yibiao' } },
+  };
+}
+
+// 工作流模板优先级：手动粘贴的 JSON > 服务器最近成功执行的工作流 > 按服务器已装模型自动组装
+async function resolveComfyUIWorkflowTemplate(baseUrl, imageConfig, options = {}) {
+  const raw = String(imageConfig?.comfyui_workflow || '').trim();
+  if (raw) {
+    return { workflow: parseComfyUIWorkflowJson(raw), source: 'custom' };
+  }
+  const historyData = await fetchComfyUIJson(baseUrl, '/history?max_items=50', options);
+  const historyWorkflow = pickComfyUIHistoryWorkflow(historyData);
+  if (historyWorkflow) {
+    return { workflow: historyWorkflow, source: 'history' };
+  }
+  const objectInfo = await fetchComfyUIJson(baseUrl, '/object_info', options);
+  const builtWorkflow = buildComfyUICheckpointWorkflow(objectInfo);
+  if (builtWorkflow) {
+    return { workflow: builtWorkflow, source: 'auto' };
+  }
+  throw new Error('未能从 ComfyUI 自动探测到可用的文生图工作流：请先在 ComfyUI 中成功运行一次文生图工作流（软件会自动复用最近一次的工作流），或在设置中粘贴 API 格式的工作流 JSON');
+}
+
+function buildComfyUIImageWorkflow(baseWorkflow, prompt, size) {
+  const workflow = JSON.parse(JSON.stringify(baseWorkflow));
+  if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) {
+    throw new Error('ComfyUI 工作流格式不正确');
+  }
+
+  const nodes = Object.entries(workflow);
+  let samplerNode = null;
+  let latentNode = null;
+  let saveNode = null;
+  for (const [, node] of nodes) {
+    if (!node || typeof node !== 'object') continue;
+    if (node.class_type === 'KSampler' || node.class_type === 'KSamplerAdvanced') samplerNode = samplerNode || node;
+    if (node.class_type === 'EmptySD3LatentImage' || node.class_type === 'EmptyLatentImage') latentNode = latentNode || node;
+    if (node.class_type === 'SaveImage') saveNode = saveNode || node;
+  }
+
+  // 正向提示词写入采样器 positive 指向的文本节点；找不到就退而取第一个文本节点
+  let promptNode = null;
+  const positiveRef = samplerNode?.inputs?.positive;
+  if (Array.isArray(positiveRef) && workflow[positiveRef[0]]?.class_type === 'CLIPTextEncode') {
+    promptNode = workflow[positiveRef[0]];
+  }
+  if (!promptNode) {
+    for (const [, node] of nodes) {
+      if (node?.class_type === 'CLIPTextEncode' && String(node.inputs?.text || '').trim()) {
+        promptNode = node;
+        break;
+      }
+    }
+  }
+  if (!promptNode) {
+    for (const [, node] of nodes) {
+      if (node?.class_type === 'CLIPTextEncode') {
+        promptNode = node;
+        break;
+      }
+    }
+  }
+  if (!promptNode) {
+    throw new Error('ComfyUI 工作流中没有 CLIPTextEncode 节点，无法注入提示词');
+  }
+  promptNode.inputs = { ...promptNode.inputs, text: prompt };
+
+  if (latentNode) {
+    latentNode.inputs = { ...latentNode.inputs, width: size.width, height: size.height };
+  }
+
+  if (samplerNode?.inputs && Object.prototype.hasOwnProperty.call(samplerNode.inputs, 'seed')) {
+    samplerNode.inputs = { ...samplerNode.inputs, seed: crypto.randomInt(0, 4294967296) };
+  } else if (samplerNode?.inputs && Object.prototype.hasOwnProperty.call(samplerNode.inputs, 'noise_seed')) {
+    samplerNode.inputs = { ...samplerNode.inputs, noise_seed: crypto.randomInt(0, 4294967296) };
+  }
+
+  if (saveNode) {
+    saveNode.inputs = { ...saveNode.inputs, filename_prefix: 'yibiao' };
+  }
+
+  return workflow;
+}
+
+async function submitComfyUIPrompt(baseUrl, workflow, options = {}) {
+  let response = null;
+  try {
+    response = await fetch(`${baseUrl}/prompt`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: workflow }),
+      signal: options.signal,
+    });
+  } catch (error) {
+    throw markAiRequestError(error, { retryable: true });
+  }
+  await ensureOk(response, 'ComfyUI 任务提交失败', { source: options.source || 'comfyui-image-model' });
+  try {
+    return await response.json();
+  } catch (error) {
+    throw markAiRequestError(error, { retryable: true });
+  }
+}
+
+function extractComfyUIImages(entry) {
+  const images = [];
+  for (const output of Object.values(entry?.outputs || {})) {
+    if (Array.isArray(output?.images)) {
+      images.push(...output.images.filter((image) => image?.filename));
+    }
+  }
+  return images;
+}
+
+function getComfyUIExecutionError(entry) {
+  const messages = Array.isArray(entry?.status?.messages) ? entry.status.messages : [];
+  for (const message of messages) {
+    if (Array.isArray(message) && message[0] === 'execution_error') {
+      const detail = message[1] || {};
+      return detail.exception_message || detail.error || 'ComfyUI 节点执行失败';
+    }
+  }
+  return 'ComfyUI 任务执行失败';
+}
+
+async function waitComfyUIImageResult(baseUrl, promptId, options = {}) {
+  const deadline = Date.now() + AI_REQUEST_TIMEOUT_MS;
+  let lastEntry = null;
+  while (Date.now() < deadline) {
+    if (options.signal?.aborted) {
+      throw createAbortError();
+    }
+    try {
+      const response = await fetch(`${baseUrl}/history/${promptId}`, { signal: options.signal });
+      if (response.ok) {
+        const data = await response.json();
+        const entry = data?.[promptId];
+        if (entry) {
+          lastEntry = entry;
+          const statusStr = entry.status?.status_str || '';
+          if (statusStr === 'error') {
+            throw createAiResponseDataError(getComfyUIExecutionError(entry), entry.status);
+          }
+          if (entry.status?.completed || statusStr === 'success') {
+            const images = extractComfyUIImages(entry);
+            if (images.length > 0) {
+              return { entry, images };
+            }
+          }
+        }
+      }
+    } catch (error) {
+      if (options.signal?.aborted || error?.name === 'AbortError') throw error;
+      if (error?.response_data) throw error;
+      // 轮询期间的瞬时网络错误不致命，继续等待
+    }
+    await sleepMs(COMFYUI_POLL_INTERVAL_MS);
+  }
+  throw createAiResponseDataError('ComfyUI 生图等待超时', lastEntry?.status || null);
+}
+
+async function fetchComfyUIImage(baseUrl, image, options = {}) {
+  const params = new URLSearchParams({
+    filename: image.filename,
+    subfolder: image.subfolder || '',
+    type: image.type || 'output',
+  });
+  let response = null;
+  try {
+    response = await fetch(`${baseUrl}/view?${params.toString()}`, { signal: options.signal });
+  } catch (error) {
+    throw markAiRequestError(error, { retryable: true });
+  }
+  await ensureOk(response, 'ComfyUI 图片下载失败', { source: options.source || 'comfyui-image-model' });
+  return {
+    buffer: Buffer.from(await response.arrayBuffer()),
+    mime_type: response.headers.get('content-type') || 'image/png',
+  };
+}
+
+async function runComfyUIImageGeneration(app, config, request, options = {}) {
+  const imageConfig = config.image_model || {};
+  const baseUrl = requireBaseUrl(imageConfig.base_url, 'ComfyUI 服务地址缺失，请在设置中填写后保存配置');
+  const prompt = options.promptOverride || normalizeImagePrompt(request);
+  const size = options.sizeOverride || resolveComfyUIImageSize(imageConfig, request.size);
+  const requestId = createRequestId();
+  const logTitle = resolveAiLogTitle(request, request.title ? `AI生图-${request.title}` : 'AI生图');
+  const logExtra = options.logExtra || {};
+  let responseData = null;
+  let analyticsTracked = false;
+
+  try {
+    const template = await resolveComfyUIWorkflowTemplate(baseUrl, imageConfig, { signal: request.signal });
+    const workflow = buildComfyUIImageWorkflow(template.workflow, prompt, size);
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: logExtra.pendingType || 'image-pending',
+      provider: 'comfyui',
+      request_mode: 'normal',
+      url: `${baseUrl}/prompt`,
+      request: { prompt, size: `${size.width}x${size.height}`, workflow_source: template.source, workflow },
+      status: 'pending',
+      created_at: new Date().toISOString(),
+    });
+    const submitted = await runWithAiRetry(() => runWithOperationTimeout(
+      (signal) => submitComfyUIPrompt(baseUrl, workflow, { signal }),
+      AI_REQUEST_TIMEOUT_MS,
+      request.signal,
+    ));
+    const promptId = submitted?.prompt_id;
+    if (!promptId) {
+      throw createAiResponseDataError('ComfyUI 未返回任务 ID', submitted);
+    }
+
+    const { entry, images } = await runWithOperationTimeout(
+      (signal) => waitComfyUIImageResult(baseUrl, promptId, { signal }),
+      AI_REQUEST_TIMEOUT_MS,
+      request.signal,
+    );
+    responseData = { prompt_id: promptId, status: entry?.status || null, images };
+    trackAiRequest(app, config, { ai_request_type: 'image' });
+    analyticsTracked = true;
+
+    const image = await runWithOperationTimeout(
+      (signal) => fetchComfyUIImage(baseUrl, images[0], { signal }),
+      AI_REQUEST_TIMEOUT_MS,
+      request.signal,
+    );
+
+    if (options.returnRawImage) {
+      writeAiLog(app, config, {
+        request_id: requestId,
+        log_title: logTitle,
+        type: logExtra.successType || 'image',
+        provider: 'comfyui',
+        request_mode: 'normal',
+        request: { prompt, size: `${size.width}x${size.height}` },
+        response: responseData,
+        result: { filename: images[0].filename },
+        created_at: new Date().toISOString(),
+      });
+      return { responseData, image, workflow_source: template.source };
+    }
+
+    const saved = saveGeneratedImage(app, image);
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: 'image',
+      provider: 'comfyui',
+      request_mode: 'normal',
+      request: { prompt, size: `${size.width}x${size.height}` },
+      response: responseData,
+      result: saved,
+      created_at: new Date().toISOString(),
+    });
+    return { success: true, title: request.title || '', ...saved };
+  } catch (error) {
+    if (!analyticsTracked) {
+      trackAiRequest(app, config, { ai_request_type: 'image' });
+    }
+    const errorMessage = options.isTest && error?.name === 'AbortError' ? IMAGE_MODEL_TEST_TIMEOUT_MESSAGE : error?.message || 'ComfyUI 生图失败';
+    writeAiLog(app, config, {
+      request_id: requestId,
+      log_title: logTitle,
+      type: logExtra.errorType || 'image-error',
+      provider: 'comfyui',
+      request_mode: 'normal',
+      request: { prompt, size: `${size.width}x${size.height}` },
+      response: getAiErrorLogResponse(error, responseData),
+      error: getAiErrorLogError(error, errorMessage),
+      created_at: new Date().toISOString(),
+    });
+    const finalError = markAiRequestError(copyRawAiErrorResponse(error, new Error(errorMessage)), { retryable: false });
+    emitAiHttpErrorToWindows(finalError);
+    throw finalError;
+  }
+}
+
+async function generateComfyUIImage(app, config, request) {
+  return runComfyUIImageGeneration(app, config, request);
+}
+
+async function testComfyUIImageModel(app, config) {
+  const testRequest = {
+    title: '测试',
+    prompt: '大字报，内容是"易标AI老好了"',
+  };
+  const { image, workflow_source: workflowSource } = await runComfyUIImageGeneration(app, config, testRequest, {
+    returnRawImage: true,
+    isTest: true,
+    logExtra: { pendingType: 'image-test-pending', successType: 'image-test', errorType: 'image-test-error' },
+  });
+  const sourceLabel = workflowSource === 'custom' ? '设置中粘贴的工作流'
+    : workflowSource === 'history' ? '服务器最近成功执行的工作流'
+      : '按服务器已装模型自动组装的工作流';
+  return {
+    success: true,
+    message: `测试成功：ComfyUI 已返回生成的图片（复用${sourceLabel}）`,
+    image_url: '',
+    image_data: image.buffer.toString('base64'),
+    mime_type: image.mime_type || 'image/png',
+  };
+}
 async function generateImageWithConfig(app, config, request) {
   const availability = getImageModelAvailability(config);
   if (!availability.available) {
@@ -1780,6 +2203,10 @@ async function generateImageWithConfig(app, config, request) {
 
   if (config.image_model?.provider === 'google-ai-studio') {
     return generateGoogleImage(app, config, request);
+  }
+
+  if (config.image_model?.provider === 'comfyui') {
+    return generateComfyUIImage(app, config, request);
   }
 
   throw new Error('当前生图服务商暂不支持正文配图');
@@ -1939,6 +2366,10 @@ function createAiService({ app, configStore }) {
 
       if (trackedConfig.image_model?.provider === 'google-ai-studio') {
         return testGoogleImageModel(app, trackedConfig);
+      }
+
+      if (trackedConfig.image_model?.provider === 'comfyui') {
+        return testComfyUIImageModel(app, trackedConfig);
       }
 
       throw new Error('当前服务商暂不支持测试');

--- a/client/electron/services/configStore.cjs
+++ b/client/electron/services/configStore.cjs
@@ -5,7 +5,7 @@ const { getConfigFilePath } = require('../utils/paths.cjs');
 
 const textModelProviders = ['jinlong', 'volcengine', 'deepseek', 'agnes', 'custom'];
 const legacyTextModelProviders = ['longcat'];
-const imageModelProviders = ['jinlong', 'volcengine', 'google-ai-studio', 'agnes', 'custom'];
+const imageModelProviders = ['jinlong', 'volcengine', 'google-ai-studio', 'agnes', 'custom', 'comfyui'];
 const aiRequestModes = ['normal', 'stream'];
 const updateChannels = ['github', 'cloudflare', 'atomgit'];
 const DEFAULT_TEXT_CONTEXT_LENGTH_LIMIT = 400000;
@@ -161,6 +161,19 @@ const defaultImageModelProfiles = {
     image_size: '1024x1024',
     request_mode: 'stream',
     concurrency_limit: DEFAULT_IMAGE_CONCURRENCY_LIMIT,
+    status: 'untested',
+    tested_at: '',
+    last_error: '',
+  },
+  comfyui: {
+    provider: 'comfyui',
+    base_url: 'http://127.0.0.1:8188',
+    api_key: '',
+    model_name: 'z-image-turbo',
+    image_size: '1024x1024',
+    request_mode: 'normal',
+    concurrency_limit: 1,
+    comfyui_workflow: '',
     status: 'untested',
     tested_at: '',
     last_error: '',
@@ -487,7 +500,7 @@ function normalizeImageModelProfile(provider, profile) {
   const useProviderDefaultImageModel = provider === 'jinlong' && !String(source.model_name ?? '').trim();
   return {
     provider,
-    base_url: provider === 'custom'
+    base_url: provider === 'custom' || provider === 'comfyui'
       ? source.base_url !== undefined ? source.base_url : defaults.base_url
       : defaults.base_url,
     api_key: source.api_key !== undefined ? source.api_key : defaults.api_key,
@@ -495,6 +508,7 @@ function normalizeImageModelProfile(provider, profile) {
     image_size: normalizeImageSize(provider, useProviderDefaultImageModel ? defaults.image_size : source.image_size, defaults.image_size),
     request_mode: normalizeAiRequestMode(useProviderDefaultImageModel ? defaults.request_mode : source.request_mode, defaults.request_mode),
     concurrency_limit: normalizeImageConcurrencyLimit(source.concurrency_limit, defaults.concurrency_limit),
+    comfyui_workflow: source.comfyui_workflow !== undefined ? String(source.comfyui_workflow) : (defaults.comfyui_workflow || ''),
     status: useProviderDefaultImageModel ? defaults.status : source.status !== undefined ? source.status : defaults.status,
     tested_at: useProviderDefaultImageModel ? defaults.tested_at : source.tested_at !== undefined ? source.tested_at : defaults.tested_at,
     last_error: useProviderDefaultImageModel ? defaults.last_error : source.last_error !== undefined ? source.last_error : defaults.last_error,

--- a/client/src/features/settings/pages/SettingsPage.tsx
+++ b/client/src/features/settings/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { trackConfigUsage } from '../../../shared/analytics/analytics';
 import { AppSwitch, DetailHelpLink, FloatingToolbar, InlineSpinner, InputWithAction, OfflineLicenseActivationDialog, useAutoAnswer, useToast } from '../../../shared/ui';
 import { showUpdateReadyToast } from '../../../shared/updateToast';
@@ -196,6 +196,7 @@ const imageProviders: Array<{ value: ImageModelProvider; label: string }> = [
   { value: 'google-ai-studio', label: 'Google AI Studio' },
   { value: 'agnes', label: 'Agnes AI' },
   { value: 'custom', label: '自定义 OpenAI-like' },
+  { value: 'comfyui', label: 'ComfyUI（本地/局域网）' },
 ];
 
 const DEFAULT_IMAGE_CONCURRENCY_LIMIT = 2;
@@ -219,7 +220,9 @@ const googleImageSizeOptions: Array<{ value: ImageModelSize; label: string }> = 
 ];
 
 function getImageSizeOptions(provider: ImageModelProvider) {
-  return provider === 'google-ai-studio' ? googleImageSizeOptions : openAICompatibleImageSizeOptions;
+  if (provider === 'google-ai-studio') return googleImageSizeOptions;
+  if (provider === 'comfyui') return openAICompatibleImageSizeOptions.filter((option) => option.value !== 'auto');
+  return openAICompatibleImageSizeOptions;
 }
 
 function normalizeImageSize(provider: ImageModelProvider, value?: string): ImageModelSize {
@@ -291,6 +294,19 @@ const imageProviderDefaults: ImageModelProfiles = {
     tested_at: '',
     last_error: '',
   },
+  comfyui: {
+    provider: 'comfyui',
+    base_url: 'http://127.0.0.1:8188',
+    api_key: '',
+    model_name: 'z-image-turbo',
+    image_size: '1024x1024',
+    request_mode: 'normal',
+    concurrency_limit: 1,
+    comfyui_workflow: '',
+    status: 'untested',
+    tested_at: '',
+    last_error: '',
+  },
 };
 
 const imageProviderApiKeyUrls: Record<ImageModelProvider, string> = {
@@ -299,6 +315,7 @@ const imageProviderApiKeyUrls: Record<ImageModelProvider, string> = {
   'google-ai-studio': 'https://aistudio.google.com/api-keys',
   agnes: 'https://platform.agnes-ai.com/settings/apiKeys',
   custom: '',
+  comfyui: '',
 };
 
 const imageProviderLabels: Record<ImageModelProvider, string> = {
@@ -307,6 +324,7 @@ const imageProviderLabels: Record<ImageModelProvider, string> = {
   'google-ai-studio': 'Google AI Studio',
   agnes: 'Agnes AI',
   custom: '自定义生图服务',
+  comfyui: 'ComfyUI',
 };
 
 function getImageBaseUrlDescription(provider: ImageModelProvider) {
@@ -314,6 +332,7 @@ function getImageBaseUrlDescription(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '火山方舟 OpenAI 兼容接口地址';
   if (provider === 'agnes') return 'Agnes AI OpenAI 兼容接口地址';
   if (provider === 'custom') return '填写兼容 OpenAI /images/generations 的接口地址';
+  if (provider === 'comfyui') return 'ComfyUI 服务地址，例如 http://127.0.0.1:8188 或局域网地址';
   return 'Google Gemini API REST 地址';
 }
 
@@ -322,6 +341,7 @@ function getImageApiKeyDescription(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '用于调用火山方舟图片生成 API';
   if (provider === 'agnes') return '用于调用 Agnes AI 图片生成 API';
   if (provider === 'custom') return '用于调用自定义 OpenAI-like 生图接口';
+  if (provider === 'comfyui') return 'ComfyUI 本地服务无需 API Key';
   return '用于调用 Google AI Studio Gemini API';
 }
 
@@ -330,6 +350,7 @@ function getImageModelDescription(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '填写火山方舟控制台中已开通的模型或推理接入点 ID';
   if (provider === 'agnes') return '填写 Agnes AI 已开通的生图模型名称';
   if (provider === 'custom') return '填写自定义接口支持的生图模型名称';
+  if (provider === 'comfyui') return '可选：粘贴 ComfyUI「Save (API Format)」导出的工作流 JSON；留空则自动复用服务器上最近成功运行的文生图工作流';
   return '选择或填写支持图片生成的 Gemini 模型';
 }
 
@@ -338,6 +359,7 @@ function getImageModelPlaceholder(provider: ImageModelProvider) {
   if (provider === 'volcengine') return '请输入已开通的模型或推理接入点 ID';
   if (provider === 'agnes') return '请输入 Agnes AI 生图模型名称';
   if (provider === 'custom') return '请输入 OpenAI-like 生图模型名称';
+  if (provider === 'comfyui') return '粘贴工作流 JSON（可选，留空自动探测）';
   return 'gemini-3.1-flash-image-preview';
 }
 
@@ -353,12 +375,13 @@ function normalizeImageModelProfile(provider: ImageModelProvider, profile?: Part
   const useProviderDefaultImageModel = provider === 'jinlong' && !String(profile?.model_name ?? '').trim();
   return {
     provider,
-    base_url: provider === 'custom' ? profile?.base_url ?? defaults.base_url : defaults.base_url,
+    base_url: provider === 'custom' || provider === 'comfyui' ? profile?.base_url ?? defaults.base_url : defaults.base_url,
     api_key: profile?.api_key ?? defaults.api_key,
     model_name: useProviderDefaultImageModel ? defaults.model_name : profile?.model_name ?? defaults.model_name,
     image_size: normalizeImageSize(provider, useProviderDefaultImageModel ? defaults.image_size : profile?.image_size ?? defaults.image_size),
     request_mode: normalizeAiRequestMode(useProviderDefaultImageModel ? defaults.request_mode : profile?.request_mode ?? defaults.request_mode),
     concurrency_limit: normalizeImageConcurrencyLimit(profile?.concurrency_limit ?? defaults.concurrency_limit),
+    comfyui_workflow: profile?.comfyui_workflow ?? defaults.comfyui_workflow ?? '',
     status: useProviderDefaultImageModel ? defaults.status : profile?.status ?? defaults.status,
     tested_at: useProviderDefaultImageModel ? defaults.tested_at : profile?.tested_at ?? defaults.tested_at,
     last_error: useProviderDefaultImageModel ? defaults.last_error : profile?.last_error ?? defaults.last_error,
@@ -429,12 +452,13 @@ function normalizeImageModelProfiles(profiles?: Partial<ImageModelProfiles>): Im
 function imageProfileFromState(imageModel: SettingsPageState['imageModel']): ImageModelConfig {
   return {
     provider: imageModel.provider,
-    base_url: imageModel.provider === 'custom' ? imageModel.base_url || '' : imageProviderDefaults[imageModel.provider].base_url,
+    base_url: imageModel.provider === 'custom' || imageModel.provider === 'comfyui' ? imageModel.base_url || '' : imageProviderDefaults[imageModel.provider].base_url,
     api_key: imageModel.api_key,
     model_name: imageModel.model_name,
     image_size: normalizeImageSize(imageModel.provider, imageModel.image_size),
     request_mode: imageModel.request_mode,
     concurrency_limit: normalizeImageConcurrencyLimit(imageModel.concurrency_limit),
+    comfyui_workflow: imageModel.comfyui_workflow || '',
     status: imageModel.status || 'untested',
     tested_at: imageModel.tested_at || '',
     last_error: imageModel.last_error || '',
@@ -1919,11 +1943,12 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
               <input
                 type="text"
                 value={state.imageModel.base_url || ''}
-                placeholder={state.imageModel.provider === 'custom' ? 'https://api.example.com/v1' : imageProviderDefaults[state.imageModel.provider].base_url}
+                placeholder={state.imageModel.provider === 'custom' ? 'https://api.example.com/v1' : state.imageModel.provider === 'comfyui' ? 'http://127.0.0.1:8188' : imageProviderDefaults[state.imageModel.provider].base_url}
                 onChange={(event) => updateImageModelConfig({ base_url: event.target.value }, { clearModels: true })}
-                disabled={state.imageModel.provider !== 'custom'}
+                disabled={state.imageModel.provider !== 'custom' && state.imageModel.provider !== 'comfyui'}
               />
             </label>
+            {state.imageModel.provider !== 'comfyui' && (
             <label className="settings-row">
               <div className="settings-row-copy">
                 <strong>API Key</strong>
@@ -1939,13 +1964,28 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                 onAction={() => { void openImageProviderApiKeyPage(); }}
               />
             </label>
+            )}
+            {state.imageModel.provider === 'comfyui' && (
+            <label className="settings-row">
+              <div className="settings-row-copy">
+                <strong>工作流 JSON</strong>
+                <span>{getImageModelDescription(state.imageModel.provider)}</span>
+              </div>
+              <textarea
+                rows={6}
+                value={state.imageModel.comfyui_workflow || ''}
+                placeholder={getImageModelPlaceholder(state.imageModel.provider)}
+                onChange={(event) => updateImageModelConfig({ comfyui_workflow: event.target.value })}
+              />
+            </label>
+            )}
             <label className="settings-row">
               <div className="settings-row-copy">
                 <strong>模型名称</strong>
-                <span>{getImageModelDescription(state.imageModel.provider)}</span>
+                <span>{state.imageModel.provider === 'comfyui' ? 'ComfyUI 由工作流决定模型，无需填写模型名称' : getImageModelDescription(state.imageModel.provider)}</span>
               </div>
               <div className="settings-control-with-action">
-                {imageModels.length > 0 ? (
+                {state.imageModel.provider !== 'comfyui' && (imageModels.length > 0 ? (
                   <select
                     value={state.imageModel.model_name}
                     onChange={(event) => updateImageModelConfig({ model_name: event.target.value })}
@@ -1959,7 +1999,8 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                     placeholder={getImageModelPlaceholder(state.imageModel.provider)}
                     onChange={(event) => updateImageModelConfig({ model_name: event.target.value })}
                   />
-                )}
+                ))}
+                {state.imageModel.provider !== 'comfyui' && (
                 <button
                   type="button"
                   className="inline-action"
@@ -1969,6 +2010,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                   {loadingModels === 'image' && <InlineSpinner />}
                   {loadingModels === 'image' ? '获取中' : '获取'}
                 </button>
+                )}
                 <button type="button" className="inline-action" onClick={testImageConfig} disabled={testingImageModel}>
                   {testingImageModel && <InlineSpinner />}
                   {testingImageModel ? '测试中' : '测试'}
@@ -1982,7 +2024,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
             <label className="settings-row">
               <div className="settings-row-copy">
                 <strong>图片尺寸</strong>
-                <span>{state.imageModel.provider === 'google-ai-studio' ? '使用 Google AI Studio 官方 imageSize 枚举' : '使用 OpenAI Image API 官方常用尺寸枚举'}</span>
+                <span>{state.imageModel.provider === 'google-ai-studio' ? '使用 Google AI Studio 官方 imageSize 枚举' : state.imageModel.provider === 'comfyui' ? '尺寸会注入工作流的 Latent 节点（宽×高）' : '使用 OpenAI Image API 官方常用尺寸枚举'}</span>
               </div>
               <select
                 value={normalizeImageSize(state.imageModel.provider, state.imageModel.image_size)}
@@ -2007,6 +2049,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                 onChange={(event) => updateImageModelConfig({ concurrency_limit: parseImageConcurrencyLimitInput(event.target.value) })}
               />
             </label>
+            {state.imageModel.provider !== 'comfyui' && (
             <label className="settings-row">
               <div className="settings-row-copy">
                 <strong>请求方式</strong>
@@ -2021,6 +2064,7 @@ function SettingsPage({ onDeveloperModeChange }: SettingsPageProps) {
                 ))}
               </select>
             </label>
+            )}
           </div>
           {imageTestPreview && (
             <div className="image-test-preview">

--- a/client/src/shared/types/config.ts
+++ b/client/src/shared/types/config.ts
@@ -43,7 +43,7 @@ export interface ImageModelTestResult {
   mime_type?: string;
 }
 
-export type ImageModelProvider = 'jinlong' | 'volcengine' | 'google-ai-studio' | 'agnes' | 'custom';
+export type ImageModelProvider = 'jinlong' | 'volcengine' | 'google-ai-studio' | 'agnes' | 'custom' | 'comfyui';
 export type ImageModelStatus = 'untested' | 'available' | 'unavailable';
 export type ImageModelSize = 'auto' | '512' | '1K' | '2K' | '4K' | '1024x1024' | '1536x1024' | '1024x1536' | '2048x2048' | '2048x1152' | '3840x2160' | '2160x3840';
 
@@ -55,6 +55,7 @@ export interface ImageModelConfig {
   image_size: ImageModelSize;
   request_mode: AiRequestMode;
   concurrency_limit: number;
+  comfyui_workflow?: string;
   status?: ImageModelStatus;
   tested_at?: string;
   last_error?: string;

--- a/client/src/styles/feature-settings.css
+++ b/client/src/styles/feature-settings.css
@@ -127,6 +127,7 @@ fieldset.settings-list {
 
 .settings-row input,
 .settings-row select,
+.settings-row textarea,
 .settings-row .settings-readonly-value {
   width: 100%;
   min-height: 36px;
@@ -147,6 +148,14 @@ fieldset.settings-list {
 
 .settings-row select {
   padding-right: 42px;
+}
+
+.settings-row textarea {
+  min-height: 132px;
+  font-family: Consolas, 'Courier New', monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  resize: vertical;
 }
 
 .settings-temperature-control {
@@ -286,7 +295,8 @@ fieldset.settings-list {
 }
 
 .settings-row input:focus,
-.settings-row select:focus {
+.settings-row select:focus,
+.settings-row textarea:focus {
   background-color: #ffffff;
   border-color: rgba(33, 116, 253, 0.5);
   box-shadow: var(--yb-focus-ring);


### PR DESCRIPTION
## 概述

为生图模型新增原生 **ComfyUI** 提供方，支持连接本地/局域网的 ComfyUI 服务（如 `http://192.168.31.70:8188`）直接生成正文配图。用户只需填写服务地址，工作流自动从服务器探测，无需粘贴任何 JSON 即可开箱即用；同时保留"粘贴 API 格式工作流 JSON"作为可选的精确覆盖手段。

## 背景与动机

现有生图提供方（Jinlong / volcengine / google-ai-studio / agnes / custom）均为云端 API，全部走 OpenAI 兼容的 `POST /images/generations` 协议。越来越多用户在本地或局域网部署 ComfyUI（自定义模型、免 API 费用、数据不出内网），但 ComfyUI 的原生协议是 `POST /prompt` 提交工作流 → 轮询 `GET /history/{id}` → `GET /view` 取图，与现有接口完全不同构，无法通过"自定义 OpenAI-like"直接接入。

## 方案设计

ComfyUI 用户的部署千差万别（不同模型、不同采样参数、不同节点结构），因此**不内置任何固定工作流**，而是按优先级自动解析工作流模板：

1. **设置中粘贴的工作流 JSON**（可选）：支持 ComfyUI "Save (API Format)" 导出，也兼容 `{prompt: {...}}` 包裹格式；解析失败时给出明确的中文错误提示。
2. **复用服务器最近成功执行的文生图工作流**（默认路径）：拉取 `GET /history?max_items=50`，识别最近一次包含 `KSampler`/`KSamplerAdvanced` + `CLIPTextEncode` + `EmptyLatentImage`/`EmptySD3LatentImage` 结构的成功执行，直接复用其完整节点配置（模型、采样器、steps、cfg 等均为用户在 ComfyUI 里调好的参数）。历史记录元组布局做了版本容错（扫描含 `class_type` 的元素，不依赖固定下标）。
3. **基于已安装 checkpoint 自动组装兜底**：若历史为空，查询 `GET /object_info`，用第一个可用 checkpoint 组装最小文生图工作流。
4. 三者皆不可用时抛出中文引导错误（提示先在 ComfyUI 里跑一次工作流）。

参数注入：将应用侧 prompt 写入采样器 `positive` 引用的 `CLIPTextEncode` 节点（带多级回退）；将尺寸档位（1024x1024 / 1024x576 / 576x1024）解析为 width/height 写入 Latent 节点；每次生成随机化 `seed`/`noise_seed`；`filename_prefix` 统一为 `yibiao`。生成结果经 `GET /view` 取回后复用现有 `saveGeneratedImage` 落盘。

## 改动内容

- `client/src/shared/types/config.ts`：`ImageModelProvider` 新增 `'comfyui'`，`ImageModelConfig` 新增可选 `comfyui_workflow` 字段。
- `client/electron/services/configStore.cjs`：新增 comfyui 默认值（`http://127.0.0.1:8188`、1024x1024、并发 1），归一化逻辑保留 base_url 可编辑及 workflow 字段。
- `client/electron/services/aiService.cjs`（核心，+431 行）：ComfyUI 工作流解析/探测/组装/注入全套实现，`runComfyUIImageGeneration` 走 `/prompt` → 轮询 `/history` → `/view` 流程，`testComfyUIImageModel` 测试连接时真实出图并在结果中注明复用的工作流来源。全程复用现有的请求队列、并发限制、600s 超时、自动重试与 AI 请求日志设施。
- `client/src/features/settings/pages/SettingsPage.tsx`：提供方下拉新增 "ComfyUI（本地/局域网）"；选中后隐藏 API Key / 模型名称 / 请求方式等不适用字段；工作流 JSON 输入框改为可选，说明文案改为"留空自动探测"。
- `client/src/styles/feature-settings.css`：工作流 JSON 文本域样式。

业务流程层（`contentIllustrationGeneration.cjs` 等消费方）零改动——它们只调 `generateImage({prompt, title, size})`，对 provider 完全无感。

## 验证

- `npx tsc --noEmit` 通过；`node --check` 两个 CJS 文件通过。
- 24 项单元检查全绿（尺寸映射、文生图结构识别、历史工作流挑选、checkpoint 兜底组装、JSON 解析与报错、参数注入、KSamplerAdvanced 的 noise_seed、不修改原对象等）。
- 对真实 ComfyUI 0.33.3 服务器（`http://192.168.31.70:8188`，Z-Image Turbo 工作流）端到端实测：自动从历史记录识别出 `z_image_turbo_bf16` 工作流，成功出图并落盘，图片内容正确。
- 应用内实测：设置页选择 ComfyUI → 填服务地址 → 测试连接通过；正文配图生成正常。