### PR TITLE
feat: 支持废标检查与标书查重结果导出 Excel

### DIFF
--- a/client/electron/ipc/duplicateCheckIpc.cjs
+++ b/client/electron/ipc/duplicateCheckIpc.cjs
@@ -1,10 +1,11 @@
 const { ipcMain } = require('electron');
 
-function registerDuplicateCheckIpc({ duplicateCheckStore }) {
+function registerDuplicateCheckIpc({ duplicateCheckStore, checkResultExportService }) {
   ipcMain.handle('duplicate-check:load-state', () => duplicateCheckStore.loadDuplicateCheck());
   ipcMain.handle('duplicate-check:save-files', (_event, payload) => duplicateCheckStore.saveFiles(payload));
   ipcMain.handle('duplicate-check:save-ui-state', (_event, payload) => duplicateCheckStore.saveUiState(payload));
   ipcMain.handle('duplicate-check:update-state', (_event, partial) => duplicateCheckStore.updateDuplicateCheckWithoutReload(partial));
+  ipcMain.handle('duplicate-check:export-excel', (_event, request) => checkResultExportService.exportDuplicateExcel(request));
   ipcMain.handle('duplicate-check:clear', () => duplicateCheckStore.clearDuplicateCheck());
 }
 

--- a/client/electron/ipc/duplicateCheckIpc.test.cjs
+++ b/client/electron/ipc/duplicateCheckIpc.test.cjs
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function loadRegisterFunction(ipcMain) {
+  const originalLoad = Module._load;
+  Module._load = function load(request, parent, isMain) {
+    if (request === 'electron') return { ipcMain };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    delete require.cache[require.resolve('./duplicateCheckIpc.cjs')];
+    return require('./duplicateCheckIpc.cjs').registerDuplicateCheckIpc;
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test('标书查重 Excel IPC 原样转发当前文件集合签名', async () => {
+  const handlers = new Map();
+  const registerDuplicateCheckIpc = loadRegisterFunction({
+    handle: (channel, handler) => handlers.set(channel, handler),
+  });
+  let receivedRequest;
+  registerDuplicateCheckIpc({
+    duplicateCheckStore: {
+      loadDuplicateCheck: () => ({}),
+      saveFiles: () => undefined,
+      saveUiState: () => undefined,
+      updateDuplicateCheckWithoutReload: () => undefined,
+      clearDuplicateCheck: () => undefined,
+    },
+    checkResultExportService: {
+      exportDuplicateExcel: async (request) => {
+        receivedRequest = request;
+        return { success: true, path: 'D:\\查重结果.xlsx' };
+      },
+    },
+  });
+
+  assert.equal(handlers.has('duplicate-check:export-excel'), true);
+  const request = { signature: 'current-signature' };
+  const result = await handlers.get('duplicate-check:export-excel')({}, request);
+  assert.deepEqual(receivedRequest, request);
+  assert.deepEqual(result, { success: true, path: 'D:\\查重结果.xlsx' });
+});

--- a/client/electron/ipc/index.cjs
+++ b/client/electron/ipc/index.cjs
@@ -1,4 +1,4 @@
-const { clipboard, ipcMain, shell } = require('electron');
+const { clipboard, dialog, ipcMain, shell } = require('electron');
 const { registerAgentIpc } = require('./agentIpc.cjs');
 const { registerAiIpc } = require('./aiIpc.cjs');
 const { registerAutoConfirmationIpc } = require('./autoConfirmationIpc.cjs');
@@ -26,6 +26,7 @@ const { createDeveloperExpansionReplaceTestService } = require('../services/deve
 const { createDonationService } = require('../services/donationService.cjs');
 const { createDuplicateCheckService } = require('../services/duplicateCheckService.cjs');
 const { createDuplicateCheckStore } = require('../services/duplicateCheckStore.cjs');
+const { createCheckResultExportService } = require('../services/checkResultExportService.cjs');
 const { createExportService } = require('../services/exportService.cjs');
 const { createFileService } = require('../services/fileService.cjs');
 const { createKnowledgeBaseService } = require('../services/knowledgeBaseService.cjs');
@@ -148,6 +149,7 @@ const workspaceDatabaseChannels = [
   'duplicate-check:load-state',
   'duplicate-check:save-files',
   'duplicate-check:save-ui-state',
+  'duplicate-check:export-excel',
   'duplicate-check:update-state',
   'duplicate-check:clear',
   'rejection-check:load-state',
@@ -156,6 +158,7 @@ const workspaceDatabaseChannels = [
   'rejection-check:remove-document',
   'rejection-check:save-ui-state',
   'rejection-check:update-state',
+  'rejection-check:export-excel',
   'rejection-check:clear',
   'knowledge-base:list',
   'knowledge-base:create-folder',
@@ -264,6 +267,12 @@ function registerWorkspaceDatabaseServices({ app, configStore, aiService, agentS
   const rejectionCheckStore = createRejectionCheckStore({ app, db: sqliteDatabase.db, fileService, technicalPlanStore, taskLogStore });
   const templateStore = createTemplateStore({ db: sqliteDatabase.db });
   const duplicateCheckService = createDuplicateCheckService({ app, configStore, workspaceStore: duplicateCheckStore });
+  const checkResultExportService = createCheckResultExportService({
+    app,
+    dialog,
+    rejectionCheckStore,
+    duplicateCheckStore,
+  });
   const taskService = createTaskService({ aiService, agentService, autoConfirmationService, technicalPlanStore, rejectionCheckStore, duplicateCheckStore, feasibilityReportStore, knowledgeBaseService, duplicateCheckService, openXmlHelperService });
   const agentWorkspaceService = createAgentWorkspaceService({ agentService, taskService, technicalPlanStore, feasibilityReportStore });
   agentWorkspaceServiceRef = agentWorkspaceService;
@@ -277,8 +286,8 @@ function registerWorkspaceDatabaseServices({ app, configStore, aiService, agentS
   registerKnowledgeBaseIpc({ knowledgeBaseService });
   registerTechnicalPlanIpc({ technicalPlanStore, taskService });
   registerFeasibilityReportIpc({ feasibilityReportStore, taskService });
-  registerDuplicateCheckIpc({ duplicateCheckStore });
-  registerRejectionCheckIpc({ rejectionCheckStore, taskService });
+  registerDuplicateCheckIpc({ duplicateCheckStore, checkResultExportService });
+  registerRejectionCheckIpc({ rejectionCheckStore, taskService, checkResultExportService });
   registerTemplateIpc({ templateStore });
   registerTaskIpc({ taskService });
   updateStatus({ phase: 'ready', ready: true, message: '本地数据库已就绪' });

--- a/client/electron/ipc/rejectionCheckIpc.cjs
+++ b/client/electron/ipc/rejectionCheckIpc.cjs
@@ -1,12 +1,13 @@
 const { ipcMain } = require('electron');
 
-function registerRejectionCheckIpc({ rejectionCheckStore, taskService }) {
+function registerRejectionCheckIpc({ rejectionCheckStore, taskService, checkResultExportService }) {
   ipcMain.handle('rejection-check:load-state', () => rejectionCheckStore.loadRejectionCheck());
   ipcMain.handle('rejection-check:import-document', (_event, role, filePaths) => taskService.importRejectionCheckDocument(role, filePaths));
   ipcMain.handle('rejection-check:import-tender-from-technical-plan', () => taskService.importRejectionCheckTenderFromTechnicalPlan());
   ipcMain.handle('rejection-check:remove-document', (_event, role, documentId) => taskService.removeRejectionCheckDocument(role, documentId));
   ipcMain.handle('rejection-check:save-ui-state', (_event, payload) => rejectionCheckStore.saveUiState(payload));
   ipcMain.handle('rejection-check:update-state', (_event, partial) => rejectionCheckStore.updateRejectionCheckWithoutReload(partial));
+  ipcMain.handle('rejection-check:export-excel', (_event, request) => checkResultExportService.exportRejectionExcel(request));
   ipcMain.handle('rejection-check:clear', () => taskService.resetRejectionCheck());
 }
 

--- a/client/electron/ipc/rejectionCheckIpc.test.cjs
+++ b/client/electron/ipc/rejectionCheckIpc.test.cjs
@@ -1,0 +1,50 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+
+function loadRegisterFunction(ipcMain) {
+  const originalLoad = Module._load;
+  Module._load = function load(request, parent, isMain) {
+    if (request === 'electron') return { ipcMain };
+    return originalLoad.call(this, request, parent, isMain);
+  };
+  try {
+    delete require.cache[require.resolve('./rejectionCheckIpc.cjs')];
+    return require('./rejectionCheckIpc.cjs').registerRejectionCheckIpc;
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+test('废标检查 Excel IPC 原样转发当前签名请求', async () => {
+  const handlers = new Map();
+  const registerRejectionCheckIpc = loadRegisterFunction({
+    handle: (channel, handler) => handlers.set(channel, handler),
+  });
+  let receivedRequest;
+  registerRejectionCheckIpc({
+    rejectionCheckStore: {
+      loadRejectionCheck: () => ({}),
+      saveUiState: () => undefined,
+      updateRejectionCheckWithoutReload: () => undefined,
+    },
+    taskService: {
+      importRejectionCheckDocument: () => undefined,
+      importRejectionCheckTenderFromTechnicalPlan: () => undefined,
+      removeRejectionCheckDocument: () => undefined,
+      resetRejectionCheck: () => undefined,
+    },
+    checkResultExportService: {
+      exportRejectionExcel: async (request) => {
+        receivedRequest = request;
+        return { success: true, path: 'D:\\结果.xlsx' };
+      },
+    },
+  });
+
+  assert.equal(handlers.has('rejection-check:export-excel'), true);
+  const request = { rejectionInputSignature: 'rejection-current', bidSignature: 'bid-current' };
+  const result = await handlers.get('rejection-check:export-excel')({}, request);
+  assert.deepEqual(receivedRequest, request);
+  assert.deepEqual(result, { success: true, path: 'D:\\结果.xlsx' });
+});

--- a/client/electron/preload.cjs
+++ b/client/electron/preload.cjs
@@ -212,6 +212,7 @@ const bridge = {
     saveFiles: (payload) => ipcRenderer.invoke('duplicate-check:save-files', payload),
     saveUiState: (payload) => ipcRenderer.invoke('duplicate-check:save-ui-state', payload),
     updateState: (partial) => ipcRenderer.invoke('duplicate-check:update-state', partial),
+    exportExcel: (request) => ipcRenderer.invoke('duplicate-check:export-excel', request),
     clear: () => ipcRenderer.invoke('duplicate-check:clear'),
   },
   rejectionCheck: {
@@ -221,6 +222,7 @@ const bridge = {
     removeDocument: (role, documentId) => ipcRenderer.invoke('rejection-check:remove-document', role, documentId),
     saveUiState: (payload) => ipcRenderer.invoke('rejection-check:save-ui-state', payload),
     updateState: (partial) => ipcRenderer.invoke('rejection-check:update-state', partial),
+    exportExcel: (request) => ipcRenderer.invoke('rejection-check:export-excel', request),
     clear: () => ipcRenderer.invoke('rejection-check:clear'),
   },
   templates: {

--- a/client/electron/services/checkResultExportService.cjs
+++ b/client/electron/services/checkResultExportService.cjs
@@ -1,0 +1,459 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const XLSX = require('xlsx');
+
+const EXCEL_TEXT_LIMIT = 32767;
+const EXCEL_TEXT_PREFIX_LIMIT = 32750;
+const EXCEL_TEXT_TRUNCATION_SUFFIX = '……（内容过长，已截断）';
+
+const rejectionSheetNames = ['检查概览', '废标项', '错别字', '逻辑问题'];
+const duplicateSheetNames = ['查重概览', '元数据', '目录重复', '文件相似度', '重复句子', '重复图片'];
+
+function normalizeCellText(value) {
+  if (value === null || value === undefined) return '';
+  const normalized = String(value)
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]/g, '');
+  if (normalized.length <= EXCEL_TEXT_LIMIT) return normalized;
+  return `${normalized.slice(0, EXCEL_TEXT_PREFIX_LIMIT)}${EXCEL_TEXT_TRUNCATION_SUFFIX}`;
+}
+
+function normalizeRows(rows) {
+  return rows.map((row) => row.map((value) => typeof value === 'number' ? value : normalizeCellText(value)));
+}
+
+function sanitizeFileName(fileName) {
+  return normalizeCellText(fileName).replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_');
+}
+
+function ensureXlsxPath(filePath) {
+  const value = String(filePath || '');
+  return /\.xlsx$/i.test(value) ? value : `${value}.xlsx`;
+}
+
+function formatFileTimestamp(date) {
+  const value = date instanceof Date ? date : new Date(date);
+  const pad = (number) => String(number).padStart(2, '0');
+  return `${value.getFullYear()}${pad(value.getMonth() + 1)}${pad(value.getDate())}_${pad(value.getHours())}${pad(value.getMinutes())}${pad(value.getSeconds())}`;
+}
+
+function formatDisplayTime(value) {
+  if (!value) return '';
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return normalizeCellText(value);
+  const pad = (number) => String(number).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function createWorksheet(rows, columnWidths, filterHeaderRow) {
+  const normalizedRows = normalizeRows(rows);
+  const worksheet = XLSX.utils.aoa_to_sheet(normalizedRows);
+  worksheet['!cols'] = columnWidths.map((wch) => ({ wch }));
+  if (Number.isInteger(filterHeaderRow)) {
+    const lastColumn = Math.max(0, (normalizedRows[filterHeaderRow]?.length || 1) - 1);
+    const lastRow = Math.max(filterHeaderRow, normalizedRows.length - 1);
+    worksheet['!autofilter'] = {
+      ref: XLSX.utils.encode_range({ s: { r: filterHeaderRow, c: 0 }, e: { r: lastRow, c: lastColumn } }),
+    };
+  }
+  return worksheet;
+}
+
+function appendWorksheet(workbook, name, rows, widths, filterHeaderRow) {
+  XLSX.utils.book_append_sheet(workbook, createWorksheet(rows, widths, filterHeaderRow), name);
+}
+
+function getRejectionResultDescriptor(result, expectedSignature) {
+  const source = result && typeof result === 'object' ? result : { status: 'idle', findings: [] };
+  const valid = source.inputSignature === expectedSignature;
+  return {
+    ...source,
+    findings: valid && Array.isArray(source.findings) ? source.findings : [],
+    valid,
+  };
+}
+
+function selectCurrentRejectionResults(state, request) {
+  const workspace = state || {};
+  const selected = {
+    bidDocuments: Array.isArray(workspace.bidDocuments) ? workspace.bidDocuments : [],
+    rejectionCheckResult: getRejectionResultDescriptor(
+      workspace.rejectionCheckResult,
+      request?.rejectionInputSignature,
+    ),
+    typoCheckResult: getRejectionResultDescriptor(workspace.typoCheckResult, request?.bidSignature),
+    logicCheckResult: getRejectionResultDescriptor(workspace.logicCheckResult, request?.bidSignature),
+  };
+  const results = [selected.rejectionCheckResult, selected.typoCheckResult, selected.logicCheckResult];
+  selected.exportable = results.some((result) => result.valid
+    && (result.status === 'success' || result.findings.length > 0));
+  return selected;
+}
+
+function getDuplicateAnalysisDescriptor(analysis, signature) {
+  const source = analysis && typeof analysis === 'object' ? analysis : undefined;
+  return {
+    source,
+    valid: Boolean(source) && source.signature === signature,
+  };
+}
+
+function countDuplicateRows(field, analysis) {
+  if (!analysis) return 0;
+  if (field === 'metadataAnalysis') return Array.isArray(analysis.rows) ? analysis.rows.length : 0;
+  if (field === 'outlineAnalysis') return Array.isArray(analysis.duplicateGroups) ? analysis.duplicateGroups.length : 0;
+  if (field === 'contentAnalysis') return Array.isArray(analysis.duplicateSentences) ? analysis.duplicateSentences.length : 0;
+  return Array.isArray(analysis.duplicateImages) ? analysis.duplicateImages.length : 0;
+}
+
+function hasDuplicateRows(field, analysis) {
+  if (countDuplicateRows(field, analysis) > 0) return true;
+  return field === 'outlineAnalysis'
+    && Array.isArray(analysis?.pairwiseSimilarities)
+    && analysis.pairwiseSimilarities.length > 0;
+}
+
+function selectCurrentDuplicateResults(state, request) {
+  const workspace = state || {};
+  const signature = request?.signature;
+  const selected = {
+    tenderFiles: Array.isArray(workspace.tenderFiles) && workspace.tenderFiles.length
+      ? workspace.tenderFiles
+      : [workspace.tenderFile].filter(Boolean),
+    bidFiles: Array.isArray(workspace.bidFiles) ? workspace.bidFiles : [],
+  };
+  for (const field of ['metadataAnalysis', 'outlineAnalysis', 'contentAnalysis', 'imageAnalysis']) {
+    selected[field] = getDuplicateAnalysisDescriptor(workspace[field], signature);
+  }
+  selected.exportable = ['metadataAnalysis', 'outlineAnalysis', 'contentAnalysis', 'imageAnalysis']
+    .some((field) => {
+      const descriptor = selected[field];
+      return descriptor.valid
+        && (descriptor.source.status === 'success' || hasDuplicateRows(field, descriptor.source));
+    });
+  return selected;
+}
+
+function getResultStatus(descriptor, idleStatus = 'idle') {
+  const source = descriptor?.source || descriptor;
+  if (!source) return '未执行';
+  if (!descriptor.valid) {
+    return source.inputSignature || source.signature ? '结果已失效' : '未执行';
+  }
+  if (source.status === 'success') return '已完成';
+  if (source.status === 'error') return '失败';
+  if (source.status === idleStatus || source.status === 'pending') return '未执行';
+  return '未执行';
+}
+
+function getResultMessage(descriptor, resultCount, emptyMessage) {
+  const source = descriptor?.source || descriptor;
+  if (!source) return '';
+  if (!descriptor.valid) {
+    return source.inputSignature || source.signature ? '结果签名与当前检查输入不一致' : '';
+  }
+  if (source.status === 'error') return source.error || source.message || source.progressMessage || '检查失败';
+  if (source.status === 'success' && resultCount === 0) return emptyMessage;
+  return source.message || source.progressMessage || '';
+}
+
+function buildDocumentLookup(documents, idField = 'id', nameField = 'fileName') {
+  return new Map((Array.isArray(documents) ? documents : []).map((document, index) => [
+    document?.[idField],
+    { index: index + 1, name: document?.[nameField] || '' },
+  ]));
+}
+
+function getDocumentColumns(lookup, documentId) {
+  const document = lookup.get(documentId);
+  return document ? [document.index, document.name] : ['', ''];
+}
+
+function buildRejectionWorkbook(state, request, options = {}) {
+  const selected = selectCurrentRejectionResults(state, request);
+  const exportedAt = options.exportedAt || new Date();
+  const workbook = XLSX.utils.book_new();
+  workbook.Props = { Title: '废标检查结果', CreatedDate: new Date(exportedAt) };
+
+  const bidNames = selected.bidDocuments.map((document) => document.fileName).filter(Boolean).join('；');
+  const overviewDefinitions = [
+    ['废标项检查', selected.rejectionCheckResult],
+    ['错别字检查', selected.typoCheckResult],
+    ['逻辑问题检查', selected.logicCheckResult],
+  ];
+  const overviewRows = [
+    ['导出时间', formatDisplayTime(exportedAt)],
+    [],
+    ['检查类型', '状态', '问题数量', '更新时间', '检查对象', '说明'],
+    ...overviewDefinitions.map(([label, result]) => [
+      label,
+      getResultStatus(result),
+      result.valid ? result.findings.length : 0,
+      result.updatedAt || '',
+      bidNames,
+      getResultMessage(result, result.findings.length, '检查已完成，未发现问题'),
+    ]),
+  ];
+  appendWorksheet(workbook, rejectionSheetNames[0], overviewRows, [16, 14, 12, 22, 32, 42]);
+
+  const documentLookup = buildDocumentLookup(selected.bidDocuments);
+  const rejectionRows = [
+    ['序号', '投标文件序号', '投标文件名', '类型', '风险等级', '标题', '摘要', '招标要求', '投标证据', '风险原因', '修改建议'],
+    ...selected.rejectionCheckResult.findings.map((finding, index) => [
+      index + 1,
+      ...getDocumentColumns(documentLookup, finding.bidDocumentId),
+      finding.type === 'invalidBid' ? '无效标' : '废标项',
+      ({ high: '高风险', medium: '中风险', low: '低风险' })[finding.severity] || '',
+      finding.title,
+      finding.summary,
+      finding.requirement,
+      finding.bidEvidence,
+      finding.riskReason,
+      finding.suggestion,
+    ]),
+  ];
+  appendWorksheet(workbook, rejectionSheetNames[1], rejectionRows, [8, 14, 28, 12, 12, 24, 36, 42, 42, 42, 42], 0);
+
+  const typoRows = [
+    ['序号', '投标文件序号', '投标文件名', '错误文本', '建议改正', '位置', '原文摘录', '判断原因'],
+    ...selected.typoCheckResult.findings.map((finding, index) => [
+      index + 1,
+      ...getDocumentColumns(documentLookup, finding.bidDocumentId),
+      finding.wrongText,
+      finding.correctText,
+      finding.locationHint,
+      finding.originalExcerpt,
+      finding.reason,
+    ]),
+  ];
+  appendWorksheet(workbook, rejectionSheetNames[2], typoRows, [8, 14, 28, 18, 18, 26, 48, 38], 0);
+
+  const logicRows = [
+    ['序号', '投标文件序号', '投标文件名', '标题', '位置', '原文', '问题原因', '修改建议'],
+    ...selected.logicCheckResult.findings.map((finding, index) => [
+      index + 1,
+      ...getDocumentColumns(documentLookup, finding.bidDocumentId),
+      finding.title,
+      finding.locationHint,
+      finding.originalText,
+      finding.fallacyReason,
+      finding.suggestion,
+    ]),
+  ];
+  appendWorksheet(workbook, rejectionSheetNames[3], logicRows, [8, 14, 28, 24, 28, 48, 42, 42], 0);
+  return workbook;
+}
+
+function joinFileNames(fileIds, fileNameById) {
+  return (Array.isArray(fileIds) ? fileIds : [])
+    .map((fileId) => fileNameById.get(fileId) || fileId)
+    .filter(Boolean)
+    .join('；');
+}
+
+function buildDuplicateWorkbook(state, request, options = {}) {
+  const selected = selectCurrentDuplicateResults(state, request);
+  const exportedAt = options.exportedAt || new Date();
+  const workbook = XLSX.utils.book_new();
+  workbook.Props = { Title: '标书查重结果', CreatedDate: new Date(exportedAt) };
+
+  const allFiles = [...selected.tenderFiles, ...selected.bidFiles];
+  const fileNameById = new Map(allFiles.map((file) => [file.id, file.file_name || '']));
+  const tenderNames = selected.tenderFiles.map((file) => file.file_name).filter(Boolean).join('；');
+  const bidNames = selected.bidFiles.map((file) => file.file_name).filter(Boolean).join('；');
+  const definitions = [
+    ['元数据', 'metadataAnalysis'],
+    ['目录', 'outlineAnalysis'],
+    ['正文', 'contentAnalysis'],
+    ['图片', 'imageAnalysis'],
+  ];
+  const overviewRows = [
+    ['导出时间', formatDisplayTime(exportedAt)],
+    [],
+    ['分析维度', '状态', '结果数量', '更新时间', '招标文件', '投标文件', '说明'],
+    ...definitions.map(([label, field]) => {
+      const descriptor = selected[field];
+      const count = descriptor.valid ? countDuplicateRows(field, descriptor.source) : 0;
+      return [
+        label,
+        getResultStatus(descriptor, 'pending'),
+        count,
+        descriptor.source?.updated_at || '',
+        tenderNames,
+        bidNames,
+        getResultMessage(descriptor, count, '分析已完成，未发现重复项'),
+      ];
+    }),
+    [],
+    ['统计项', '数值'],
+    ['识别图片总数', selected.imageAnalysis.valid ? Number(selected.imageAnalysis.source.totalImageCount || 0) : 0],
+    ['招标目录排除数量', selected.outlineAnalysis.valid ? Number(selected.outlineAnalysis.source.tenderMatchedItemCount || 0) : 0],
+    ['招标引用句子排除数量', selected.contentAnalysis.valid ? Number(selected.contentAnalysis.source.tenderMatchedSentenceCount || 0) : 0],
+    ['正文句子总量', selected.contentAnalysis.valid ? Number(selected.contentAnalysis.source.totalSentenceCount || 0) : 0],
+  ];
+  appendWorksheet(workbook, duplicateSheetNames[0], overviewRows, [16, 14, 12, 22, 30, 34, 42]);
+
+  const metadata = selected.metadataAnalysis.valid ? selected.metadataAnalysis.source : undefined;
+  const metadataRows = [
+    ['元数据项', '重复文件', '同日文件', ...selected.bidFiles.map((file, index) => `投标文件${index + 1}：${file.file_name}`)],
+    ...(metadata?.rows || []).map((row) => [
+      row.label,
+      joinFileNames(row.duplicate_file_ids, fileNameById),
+      joinFileNames(row.same_day_file_ids, fileNameById),
+      ...selected.bidFiles.map((file) => row.values?.[file.id]),
+    ]),
+  ];
+  appendWorksheet(workbook, duplicateSheetNames[1], metadataRows, [24, 32, 32, ...selected.bidFiles.map(() => 32)], 0);
+
+  const outline = selected.outlineAnalysis.valid ? selected.outlineAnalysis.source : undefined;
+  const outlineRows = [
+    ['序号', '类型', '标题', '相似度', '涉及文件', '路径明细'],
+    ...(outline?.duplicateGroups || []).map((group, index) => [
+      index + 1,
+      group.type === 'duplicate' ? '重复' : '相似',
+      group.title,
+      Number(group.score || 0),
+      joinFileNames(group.file_ids, fileNameById),
+      (group.file_ids || []).flatMap((fileId) => (group.paths?.[fileId] || []).map((itemPath) => `${fileNameById.get(fileId) || fileId}：${itemPath}`)).join('；'),
+    ]),
+  ];
+  appendWorksheet(workbook, duplicateSheetNames[2], outlineRows, [8, 10, 32, 12, 34, 64], 0);
+  const outlineSheet = workbook.Sheets[duplicateSheetNames[2]];
+  for (let row = 1; row < outlineRows.length; row += 1) {
+    const cell = outlineSheet[XLSX.utils.encode_cell({ r: row, c: 3 })];
+    if (cell) cell.z = '0.00%';
+  }
+
+  const pairwiseRows = [
+    ['文件 A', '文件 B', '综合相似度', '标题重合度', '路径重合度', '顺序相似度', '共享目录数量', '风险等级'],
+    ...(outline?.pairwiseSimilarities || []).map((item) => [
+      fileNameById.get(item.file_a_id) || item.file_a_id,
+      fileNameById.get(item.file_b_id) || item.file_b_id,
+      Number(item.score || 0),
+      Number(item.title_overlap || 0),
+      Number(item.path_overlap || 0),
+      Number(item.order_similarity || 0),
+      Number(item.shared_count || 0),
+      ({ high: '高', medium: '中', low: '低', none: '无' })[item.risk] || '无',
+    ]),
+  ];
+  appendWorksheet(workbook, duplicateSheetNames[3], pairwiseRows, [28, 28, 14, 14, 14, 14, 14, 12], 0);
+  const pairwiseSheet = workbook.Sheets[duplicateSheetNames[3]];
+  for (let row = 1; row < pairwiseRows.length; row += 1) {
+    for (let column = 2; column <= 5; column += 1) {
+      const cell = pairwiseSheet[XLSX.utils.encode_cell({ r: row, c: column })];
+      if (cell) cell.z = '0.00%';
+    }
+  }
+
+  const content = selected.contentAnalysis.valid ? selected.contentAnalysis.source : undefined;
+  const contentRows = [
+    ['序号', '重复句子', '涉及文件', '各文件出现次数', '总出现次数'],
+    ...(content?.duplicateSentences || []).map((item, index) => [
+      index + 1,
+      item.sentence,
+      joinFileNames(item.file_ids, fileNameById),
+      (item.file_ids || []).map((fileId) => `${fileNameById.get(fileId) || fileId} × ${Number(item.occurrences?.[fileId] || 0)}`).join('；'),
+      Object.values(item.occurrences || {}).reduce((sum, count) => sum + Number(count || 0), 0),
+    ]),
+  ];
+  appendWorksheet(workbook, duplicateSheetNames[4], contentRows, [8, 72, 34, 48, 14], 0);
+
+  const image = selected.imageAnalysis.valid ? selected.imageAnalysis.source : undefined;
+  const imageRows = [
+    ['序号', '图片 Hash', '涉及文件', '各文件出现次数', '出现位置', '图片前文'],
+    ...(image?.duplicateImages || []).map((item, index) => {
+      const locationEntries = (item.file_ids || []).flatMap((fileId) => (item.locations?.[fileId] || []).map((location) => ({ fileId, location })));
+      return [
+        index + 1,
+        item.hash,
+        joinFileNames(item.file_ids, fileNameById),
+        (item.file_ids || []).map((fileId) => `${fileNameById.get(fileId) || fileId} × ${Number(item.occurrences?.[fileId] || 0)}`).join('；'),
+        locationEntries.map(({ fileId, location }) => {
+          const indexText = Number.isFinite(Number(location.image_index)) ? `（图片 ${Number(location.image_index)}）` : '';
+          return `${fileNameById.get(fileId) || fileId}：${location.directory || '未识别目录'}${indexText}`;
+        }).join('；'),
+        locationEntries.map(({ fileId, location }) => `${fileNameById.get(fileId) || fileId}：${location.previous_sentence || ''}`).join('；'),
+      ];
+    }),
+  ];
+  appendWorksheet(workbook, duplicateSheetNames[5], imageRows, [8, 40, 34, 48, 64, 72], 0);
+  return workbook;
+}
+
+function workbookToBuffer(workbook) {
+  return XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer', compression: true });
+}
+
+function createCheckResultExportService({
+  app,
+  dialog,
+  rejectionCheckStore,
+  duplicateCheckStore,
+  fileSystem = fs,
+  now = () => new Date(),
+}) {
+  async function saveWorkbook({ title, defaultFileName, workbook }) {
+    const defaultDir = app?.getPath ? app.getPath('downloads') : process.env.USERPROFILE || process.cwd();
+    const saveResult = await dialog.showSaveDialog({
+      title,
+      defaultPath: path.join(defaultDir, sanitizeFileName(defaultFileName)),
+      filters: [{ name: 'Excel 工作簿', extensions: ['xlsx'] }],
+    });
+    if (saveResult.canceled || !saveResult.filePath) {
+      return { success: false, canceled: true, message: '已取消导出' };
+    }
+    const outputPath = ensureXlsxPath(saveResult.filePath);
+    fileSystem.writeFileSync(outputPath, workbookToBuffer(workbook));
+    return { success: true, path: outputPath, message: 'Excel 已导出' };
+  }
+
+  async function exportRejectionExcel(request) {
+    try {
+      const state = rejectionCheckStore.loadRejectionCheck();
+      const selected = selectCurrentRejectionResults(state, request);
+      if (!selected.exportable) return { success: false, message: '没有可导出的当前废标检查结果' };
+      const exportedAt = now();
+      const workbook = buildRejectionWorkbook(state, request, { exportedAt });
+      return await saveWorkbook({
+        title: '导出废标检查结果',
+        defaultFileName: `废标检查结果_${formatFileTimestamp(exportedAt)}.xlsx`,
+        workbook,
+      });
+    } catch (error) {
+      return { success: false, message: error instanceof Error ? error.message : '废标检查结果导出失败' };
+    }
+  }
+
+  async function exportDuplicateExcel(request) {
+    try {
+      const state = duplicateCheckStore.loadDuplicateCheck();
+      const selected = selectCurrentDuplicateResults(state, request);
+      if (!selected.exportable) return { success: false, message: '没有可导出的当前标书查重结果' };
+      const exportedAt = now();
+      const workbook = buildDuplicateWorkbook(state, request, { exportedAt });
+      return await saveWorkbook({
+        title: '导出标书查重结果',
+        defaultFileName: `标书查重结果_${formatFileTimestamp(exportedAt)}.xlsx`,
+        workbook,
+      });
+    } catch (error) {
+      return { success: false, message: error instanceof Error ? error.message : '标书查重结果导出失败' };
+    }
+  }
+
+  return { exportRejectionExcel, exportDuplicateExcel };
+}
+
+module.exports = {
+  createCheckResultExportService,
+  __test__: {
+    buildRejectionWorkbook,
+    buildDuplicateWorkbook,
+    selectCurrentRejectionResults,
+    selectCurrentDuplicateResults,
+    normalizeCellText,
+    sanitizeFileName,
+    ensureXlsxPath,
+    workbookToBuffer,
+  },
+};

--- a/client/electron/services/checkResultExportService.test.cjs
+++ b/client/electron/services/checkResultExportService.test.cjs
@@ -1,0 +1,343 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const XLSX = require('xlsx');
+const { createCheckResultExportService, __test__ } = require('./checkResultExportService.cjs');
+
+function roundTripWorkbook(workbook) {
+  const buffer = XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' });
+  return XLSX.read(buffer, { type: 'buffer', cellNF: true });
+}
+
+function sheetRows(workbook, name) {
+  return XLSX.utils.sheet_to_json(workbook.Sheets[name], { header: 1, defval: '' });
+}
+
+function createRejectionState() {
+  return {
+    bidDocuments: [
+      { id: 'bid-a', fileName: '甲公司投标文件.docx' },
+      { id: 'bid-b', fileName: '乙公司投标文件.docx' },
+    ],
+    rejectionCheckResult: {
+      status: 'success',
+      inputSignature: 'rejection-current',
+      updatedAt: '2026-08-31T01:02:03.000Z',
+      findings: [{
+        id: 'risk-1',
+        bidDocumentId: 'bid-b',
+        type: 'invalidBid',
+        severity: 'high',
+        title: '签字缺失',
+        summary: '法定代表人未签字',
+        requirement: '必须签字',
+        bidEvidence: '签字栏为空',
+        riskReason: '可能被认定为无效标',
+        suggestion: '补充签字',
+      }],
+    },
+    typoCheckResult: {
+      status: 'success',
+      inputSignature: 'bid-current',
+      updatedAt: '2026-08-31T02:03:04.000Z',
+      findings: [{
+        id: 'typo-1',
+        bidDocumentId: 'bid-a',
+        wrongText: '项目经里',
+        correctText: '项目经理',
+        originalExcerpt: '由项目经里负责',
+        reason: '词语错误',
+      }],
+    },
+    logicCheckResult: {
+      status: 'success',
+      inputSignature: 'bid-current',
+      updatedAt: '2026-08-31T03:04:05.000Z',
+      findings: [{
+        id: 'logic-1',
+        bidDocumentId: 'bid-a',
+        title: '工期矛盾',
+        originalText: '工期为30天，计划用时45天',
+        locationHint: '施工组织设计第2章',
+        fallacyReason: '计划工期超过承诺工期',
+        suggestion: '统一为30天以内',
+      }],
+    },
+  };
+}
+
+function createDuplicateState() {
+  const bidFiles = [
+    { id: 'file-a', file_name: 'A公司投标文件.docx' },
+    { id: 'file-b', file_name: 'B公司投标文件.docx' },
+  ];
+  return {
+    tenderFiles: [{ id: 'tender-a', file_name: '招标文件.docx' }],
+    bidFiles,
+    metadataAnalysis: {
+      status: 'success',
+      signature: 'duplicate-current',
+      updated_at: '2026-08-31T04:05:06.000Z',
+      message: '元数据分析完成',
+      rows: [{
+        key: 'creator',
+        label: '作者',
+        values: { 'file-a': '张三', 'file-b': '张三' },
+        duplicate_file_ids: ['file-a', 'file-b'],
+        same_day_file_ids: [],
+      }, {
+        key: 'created',
+        label: '创建日期',
+        values: { 'file-a': '2026-08-30 09:00', 'file-b': '2026-08-30 18:00' },
+        duplicate_file_ids: [],
+        same_day_file_ids: ['file-a', 'file-b'],
+      }],
+    },
+    outlineAnalysis: {
+      status: 'success',
+      signature: 'duplicate-current',
+      updated_at: '2026-08-31T05:06:07.000Z',
+      message: '目录分析完成',
+      tenderMatchedItemCount: 3,
+      duplicateGroups: [{
+        id: 'group-1',
+        type: 'similar',
+        title: '施工方案',
+        score: 0.875,
+        file_ids: ['file-a', 'file-b'],
+        item_ids: { 'file-a': ['a-1'], 'file-b': ['b-1'] },
+        paths: { 'file-a': ['第一章 > 施工方案'], 'file-b': ['第二章 > 实施方案'] },
+      }],
+      pairwiseSimilarities: [{
+        file_a_id: 'file-a',
+        file_b_id: 'file-b',
+        score: 0.8,
+        title_overlap: 0.75,
+        path_overlap: 0.6,
+        order_similarity: 0.9,
+        shared_count: 4,
+        risk: 'high',
+      }],
+    },
+    contentAnalysis: {
+      status: 'success',
+      signature: 'duplicate-current',
+      updated_at: '2026-08-31T06:07:08.000Z',
+      message: '正文分析完成',
+      tenderMatchedSentenceCount: 5,
+      totalSentenceCount: 120,
+      duplicateSentences: [{
+        id: 'sentence-1',
+        sentence: '本项目将严格按照招标文件要求实施。',
+        file_ids: ['file-a', 'file-b'],
+        occurrences: { 'file-a': 2, 'file-b': 1 },
+      }],
+    },
+    imageAnalysis: {
+      status: 'success',
+      signature: 'duplicate-current',
+      updated_at: '2026-08-31T07:08:09.000Z',
+      message: '图片分析完成',
+      totalImageCount: 18,
+      duplicateImages: [{
+        id: 'image-1',
+        hash: 'abc123',
+        preview_url: 'yibiao-asset://imported-images/internal.png',
+        file_ids: ['file-a', 'file-b'],
+        occurrences: { 'file-a': 2, 'file-b': 1 },
+        locations: {
+          'file-a': [
+            { image_index: 2, directory: '第一章/组织架构', previous_sentence: '组织架构如下。' },
+            { image_index: 8, directory: '第三章/人员安排', previous_sentence: '人员安排如下。' },
+          ],
+          'file-b': [{ image_index: 3, directory: '第二章/组织架构', previous_sentence: '项目架构如下。' }],
+        },
+      }],
+    },
+  };
+}
+
+test('废标检查工作簿固定生成四张工作表并完整映射三类结果', () => {
+  const workbook = roundTripWorkbook(__test__.buildRejectionWorkbook(
+    createRejectionState(),
+    { rejectionInputSignature: 'rejection-current', bidSignature: 'bid-current' },
+    { exportedAt: new Date('2026-09-01T08:09:10.000Z') },
+  ));
+  assert.deepEqual(workbook.SheetNames, ['检查概览', '废标项', '错别字', '逻辑问题']);
+
+  const overview = sheetRows(workbook, '检查概览');
+  assert.deepEqual(overview[2], ['检查类型', '状态', '问题数量', '更新时间', '检查对象', '说明']);
+  assert.deepEqual(overview[3].slice(0, 5), ['废标项检查', '已完成', 1, '2026-08-31T01:02:03.000Z', '甲公司投标文件.docx；乙公司投标文件.docx']);
+
+  const rejection = sheetRows(workbook, '废标项');
+  assert.deepEqual(rejection[1], [1, 2, '乙公司投标文件.docx', '无效标', '高风险', '签字缺失', '法定代表人未签字', '必须签字', '签字栏为空', '可能被认定为无效标', '补充签字']);
+
+  const typo = sheetRows(workbook, '错别字');
+  assert.deepEqual(typo[1], [1, 1, '甲公司投标文件.docx', '项目经里', '项目经理', '', '由项目经里负责', '词语错误']);
+  assert.equal(typo.flat().includes('undefined'), false);
+
+  const logic = sheetRows(workbook, '逻辑问题');
+  assert.deepEqual(logic[1], [1, 1, '甲公司投标文件.docx', '工期矛盾', '施工组织设计第2章', '工期为30天，计划用时45天', '计划工期超过承诺工期', '统一为30天以内']);
+});
+
+test('废标检查按不同签名筛选三类结果且保留成功零问题报告', () => {
+  const state = createRejectionState();
+  state.rejectionCheckResult.inputSignature = 'rejection-old';
+  state.typoCheckResult = { status: 'success', inputSignature: 'bid-current', findings: [] };
+  state.logicCheckResult = { status: 'error', inputSignature: 'bid-old', findings: [{ id: 'old' }] };
+
+  const selected = __test__.selectCurrentRejectionResults(state, {
+    rejectionInputSignature: 'rejection-current',
+    bidSignature: 'bid-current',
+  });
+  assert.equal(selected.exportable, true);
+  assert.equal(selected.rejectionCheckResult.valid, false);
+  assert.deepEqual(selected.rejectionCheckResult.findings, []);
+  assert.equal(selected.typoCheckResult.valid, true);
+  assert.deepEqual(selected.typoCheckResult.findings, []);
+  assert.equal(selected.logicCheckResult.valid, false);
+  assert.deepEqual(selected.logicCheckResult.findings, []);
+
+  const workbook = roundTripWorkbook(__test__.buildRejectionWorkbook(state, {
+    rejectionInputSignature: 'rejection-current',
+    bidSignature: 'bid-current',
+  }));
+  assert.deepEqual(sheetRows(workbook, '废标项'), [[
+    '序号', '投标文件序号', '投标文件名', '类型', '风险等级', '标题', '摘要', '招标要求', '投标证据', '风险原因', '修改建议',
+  ]]);
+  assert.deepEqual(sheetRows(workbook, '错别字'), [[
+    '序号', '投标文件序号', '投标文件名', '错误文本', '建议改正', '位置', '原文摘录', '判断原因',
+  ]]);
+  assert.equal(sheetRows(workbook, '检查概览')[4][5], '检查已完成，未发现问题');
+});
+
+test('查重工作簿固定生成六张工作表并导出所有现有分析维度', () => {
+  const workbook = roundTripWorkbook(__test__.buildDuplicateWorkbook(
+    createDuplicateState(),
+    { signature: 'duplicate-current' },
+    { exportedAt: new Date('2026-09-01T08:09:10.000Z') },
+  ));
+  assert.deepEqual(workbook.SheetNames, ['查重概览', '元数据', '目录重复', '文件相似度', '重复句子', '重复图片']);
+
+  const overview = sheetRows(workbook, '查重概览');
+  assert.deepEqual(overview.slice(-4).map((row) => row.slice(0, 2)), [
+    ['识别图片总数', 18],
+    ['招标目录排除数量', 3],
+    ['招标引用句子排除数量', 5],
+    ['正文句子总量', 120],
+  ]);
+
+  const metadata = sheetRows(workbook, '元数据');
+  assert.deepEqual(metadata[0], ['元数据项', '重复文件', '同日文件', '投标文件1：A公司投标文件.docx', '投标文件2：B公司投标文件.docx']);
+  assert.deepEqual(metadata[1], ['作者', 'A公司投标文件.docx；B公司投标文件.docx', '', '张三', '张三']);
+  assert.deepEqual(metadata[2], ['创建日期', '', 'A公司投标文件.docx；B公司投标文件.docx', '2026-08-30 09:00', '2026-08-30 18:00']);
+
+  const outline = sheetRows(workbook, '目录重复');
+  assert.deepEqual(outline[1], [1, '相似', '施工方案', 0.875, 'A公司投标文件.docx；B公司投标文件.docx', 'A公司投标文件.docx：第一章 > 施工方案；B公司投标文件.docx：第二章 > 实施方案']);
+  assert.equal(workbook.Sheets['目录重复'].D2.z, '0.00%');
+
+  const pairwise = sheetRows(workbook, '文件相似度');
+  assert.deepEqual(pairwise[1], ['A公司投标文件.docx', 'B公司投标文件.docx', 0.8, 0.75, 0.6, 0.9, 4, '高']);
+  assert.equal(workbook.Sheets['文件相似度'].C2.z, '0.00%');
+  assert.equal(workbook.Sheets['文件相似度'].F2.z, '0.00%');
+
+  const sentences = sheetRows(workbook, '重复句子');
+  assert.deepEqual(sentences[1], [1, '本项目将严格按照招标文件要求实施。', 'A公司投标文件.docx；B公司投标文件.docx', 'A公司投标文件.docx × 2；B公司投标文件.docx × 1', 3]);
+
+  const images = sheetRows(workbook, '重复图片');
+  assert.equal(images[1][1], 'abc123');
+  assert.equal(images[1][3], 'A公司投标文件.docx × 2；B公司投标文件.docx × 1');
+  assert.match(images[1][4], /A公司投标文件\.docx：第一章\/组织架构（图片 2）/);
+  assert.match(images[1][4], /A公司投标文件\.docx：第三章\/人员安排（图片 8）/);
+  assert.match(images[1][4], /B公司投标文件\.docx：第二章\/组织架构（图片 3）/);
+  assert.match(images[1][5], /人员安排如下。/);
+  assert.equal(images.flat().some((value) => String(value).includes('yibiao-asset://')), false);
+});
+
+test('查重按每个维度签名筛选，旧结果不进入工作簿，成功零结果仍可导出', () => {
+  const state = createDuplicateState();
+  state.metadataAnalysis.signature = 'duplicate-old';
+  state.outlineAnalysis = { status: 'success', signature: 'duplicate-current', duplicateGroups: [], pairwiseSimilarities: [] };
+  state.contentAnalysis = { status: 'error', signature: 'duplicate-old', duplicateSentences: [{ id: 'old' }] };
+  state.imageAnalysis = undefined;
+
+  const selected = __test__.selectCurrentDuplicateResults(state, { signature: 'duplicate-current' });
+  assert.equal(selected.exportable, true);
+  assert.equal(selected.metadataAnalysis.valid, false);
+  assert.equal(selected.outlineAnalysis.valid, true);
+  assert.equal(selected.contentAnalysis.valid, false);
+  assert.equal(selected.imageAnalysis.valid, false);
+
+  const workbook = roundTripWorkbook(__test__.buildDuplicateWorkbook(state, { signature: 'duplicate-current' }));
+  assert.equal(sheetRows(workbook, '元数据').length, 1);
+  assert.equal(sheetRows(workbook, '目录重复').length, 1);
+  assert.equal(sheetRows(workbook, '文件相似度').length, 1);
+  assert.equal(sheetRows(workbook, '重复句子').length, 1);
+  assert.equal(sheetRows(workbook, '查重概览')[4][6], '分析已完成，未发现重复项');
+});
+
+test('文本归一化移除 XML 控制字符、保留空格换行并稳定截断超长单元格', () => {
+  assert.equal(__test__.normalizeCellText(null), '');
+  assert.equal(__test__.normalizeCellText(undefined), '');
+  assert.equal(__test__.normalizeCellText('  第一行\n第二行\u0001  '), '  第一行\n第二行  ');
+  const normalized = __test__.normalizeCellText('长'.repeat(40000));
+  assert.equal(normalized.length, 32750 + '……（内容过长，已截断）'.length);
+  assert.equal(normalized.startsWith('长'.repeat(32750)), true);
+  assert.equal(normalized.endsWith('……（内容过长，已截断）'), true);
+});
+
+test('保存服务在取消时不写文件', async () => {
+  const writes = [];
+  const service = createCheckResultExportService({
+    app: { getPath: () => 'C:\\用户\\下载' },
+    dialog: { showSaveDialog: async () => ({ canceled: true }) },
+    rejectionCheckStore: { loadRejectionCheck: () => createRejectionState() },
+    duplicateCheckStore: { loadDuplicateCheck: () => createDuplicateState() },
+    fileSystem: { writeFileSync: (...args) => writes.push(args) },
+    now: () => new Date('2026-09-01T08:09:10.000Z'),
+  });
+  const result = await service.exportRejectionExcel({ rejectionInputSignature: 'rejection-current', bidSignature: 'bid-current' });
+  assert.deepEqual(result, { success: false, canceled: true, message: '已取消导出' });
+  assert.deepEqual(writes, []);
+});
+
+test('保存服务补充 xlsx 扩展名并写入可重新读取的真实工作簿 Buffer', async () => {
+  const writes = [];
+  let saveOptions;
+  const service = createCheckResultExportService({
+    app: { getPath: () => 'C:\\用户\\下载' },
+    dialog: {
+      showSaveDialog: async (options) => {
+        saveOptions = options;
+        return { canceled: false, filePath: 'D:\\中文目录\\查重结果' };
+      },
+    },
+    rejectionCheckStore: { loadRejectionCheck: () => createRejectionState() },
+    duplicateCheckStore: { loadDuplicateCheck: () => createDuplicateState() },
+    fileSystem: { writeFileSync: (...args) => writes.push(args) },
+    now: () => new Date(2026, 8, 1, 8, 9, 10),
+  });
+  const result = await service.exportDuplicateExcel({ signature: 'duplicate-current' });
+  assert.deepEqual(result, { success: true, path: 'D:\\中文目录\\查重结果.xlsx', message: 'Excel 已导出' });
+  assert.equal(saveOptions.defaultPath.endsWith('标书查重结果_20260901_080910.xlsx'), true);
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0][0], 'D:\\中文目录\\查重结果.xlsx');
+  assert.ok(Buffer.isBuffer(writes[0][1]));
+  const reopened = XLSX.read(writes[0][1], { type: 'buffer' });
+  assert.deepEqual(reopened.SheetNames, ['查重概览', '元数据', '目录重复', '文件相似度', '重复句子', '重复图片']);
+});
+
+test('仅有当前错误状态且没有结果行时服务拒绝导出', async () => {
+  const state = createRejectionState();
+  state.rejectionCheckResult = { status: 'error', inputSignature: 'rejection-current', findings: [] };
+  state.typoCheckResult = { status: 'error', inputSignature: 'bid-current', findings: [] };
+  state.logicCheckResult = { status: 'idle', inputSignature: 'bid-current', findings: [] };
+  const service = createCheckResultExportService({
+    dialog: { showSaveDialog: async () => assert.fail('不应打开保存对话框') },
+    rejectionCheckStore: { loadRejectionCheck: () => state },
+    duplicateCheckStore: { loadDuplicateCheck: () => createDuplicateState() },
+  });
+  assert.deepEqual(
+    await service.exportRejectionExcel({ rejectionInputSignature: 'rejection-current', bidSignature: 'bid-current' }),
+    { success: false, message: '没有可导出的当前废标检查结果' },
+  );
+});

--- a/client/src/features/duplicate-check/exportState.test.cjs
+++ b/client/src/features/duplicate-check/exportState.test.cjs
@@ -1,0 +1,40 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+
+function loadExportStateModule() {
+  const source = fs.readFileSync(path.join(__dirname, 'exportState.ts'), 'utf-8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  const module = { exports: {} };
+  Function('module', 'exports', 'require', compiled)(module, module.exports, require);
+  return module.exports;
+}
+
+const { hasExportableDuplicateResults } = loadExportStateModule();
+
+test('当前签名任一分析成功时允许导出零重复报告', () => {
+  assert.equal(hasExportableDuplicateResults({
+    metadataAnalysis: { status: 'success', signature: 'current', rows: [] },
+    signature: 'current',
+  }), true);
+});
+
+test('当前签名已产生目录相似度时即使状态错误也允许导出', () => {
+  assert.equal(hasExportableDuplicateResults({
+    outlineAnalysis: { status: 'error', signature: 'current', duplicateGroups: [], pairwiseSimilarities: [{ score: 0.5 }] },
+    signature: 'current',
+  }), true);
+});
+
+test('旧签名结果和仅错误空结果不能启用查重导出', () => {
+  assert.equal(hasExportableDuplicateResults({
+    metadataAnalysis: { status: 'success', signature: 'old', rows: [{ key: 'creator' }] },
+    contentAnalysis: { status: 'error', signature: 'current', duplicateSentences: [] },
+    imageAnalysis: { status: 'success', signature: 'old', duplicateImages: [{ id: 'image' }] },
+    signature: 'current',
+  }), false);
+});

--- a/client/src/features/duplicate-check/exportState.ts
+++ b/client/src/features/duplicate-check/exportState.ts
@@ -1,0 +1,36 @@
+import type { DuplicateContentAnalysisState, DuplicateImageAnalysisState, DuplicateMetadataAnalysisState, DuplicateOutlineAnalysisState } from '../../shared/types';
+
+function hasCurrentAnalysisResult(
+  analysis: DuplicateMetadataAnalysisState | DuplicateOutlineAnalysisState | DuplicateContentAnalysisState | DuplicateImageAnalysisState | undefined,
+  signature: string,
+  resultCount: number,
+) {
+  return Boolean(
+    signature
+    && analysis?.signature === signature
+    && (analysis.status === 'success' || resultCount > 0),
+  );
+}
+
+export function hasExportableDuplicateResults({
+  metadataAnalysis,
+  outlineAnalysis,
+  contentAnalysis,
+  imageAnalysis,
+  signature,
+}: {
+  metadataAnalysis?: DuplicateMetadataAnalysisState;
+  outlineAnalysis?: DuplicateOutlineAnalysisState;
+  contentAnalysis?: DuplicateContentAnalysisState;
+  imageAnalysis?: DuplicateImageAnalysisState;
+  signature: string;
+}) {
+  return hasCurrentAnalysisResult(metadataAnalysis, signature, metadataAnalysis?.rows?.length || 0)
+    || hasCurrentAnalysisResult(
+      outlineAnalysis,
+      signature,
+      (outlineAnalysis?.duplicateGroups?.length || 0) + (outlineAnalysis?.pairwiseSimilarities?.length || 0),
+    )
+    || hasCurrentAnalysisResult(contentAnalysis, signature, contentAnalysis?.duplicateSentences?.length || 0)
+    || hasCurrentAnalysisResult(imageAnalysis, signature, imageAnalysis?.duplicateImages?.length || 0);
+}

--- a/client/src/features/duplicate-check/pages/DuplicateCheckPage.tsx
+++ b/client/src/features/duplicate-check/pages/DuplicateCheckPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { trackPageView } from '../../../shared/analytics/analytics';
-import { FloatingToolbar, isLibreOfficeRequiredMessage, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
+import { AppDialog, FloatingToolbar, isLibreOfficeRequiredMessage, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, ToolbarDocumentIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
 import type { FloatingToolbarGroup } from '../../../shared/ui';
+import { hasExportableDuplicateResults } from '../exportState';
 import type { DuplicateAnalysisStatus, DuplicateAnalysisTabId, DuplicateCheckStep, DuplicateCheckTaskState, DuplicateCheckWorkspaceState, DuplicateContentAnalysisState, DuplicateImageAnalysisState, DuplicateMetadataAnalysisState, DuplicateOutlineAnalysisState, LocalFileSelection } from '../../../shared/types';
 
 const guideItems = [
@@ -606,6 +607,8 @@ function DuplicateCheckPage() {
   const [analysisTask, setAnalysisTask] = useState<DuplicateCheckTaskState | undefined>();
   const [startingAnalysis, setStartingAnalysis] = useState(false);
   const [busy, setBusy] = useState<'tender' | 'bid' | null>(null);
+  const [exportingExcel, setExportingExcel] = useState(false);
+  const [exportedExcelPath, setExportedExcelPath] = useState('');
   const [analyticsReady, setAnalyticsReady] = useState(false);
   const startedMetadataSignatureRef = useRef<string | null>(null);
   const currentAnalysisSignatureRef = useRef('');
@@ -743,6 +746,13 @@ function DuplicateCheckPage() {
     const files: LocalFileSelection[] = [...tenderFiles, ...bidFiles];
     return createDuplicateCheckSignature(files);
   }, [bidFiles, tenderFiles]);
+  const hasExportableCurrentResult = hasExportableDuplicateResults({
+    metadataAnalysis,
+    outlineAnalysis,
+    contentAnalysis,
+    imageAnalysis,
+    signature: currentAnalysisSignature,
+  });
 
   useEffect(() => {
     currentAnalysisSignatureRef.current = currentAnalysisSignature;
@@ -886,6 +896,38 @@ function DuplicateCheckPage() {
     }
   };
 
+  async function exportDuplicateResultsExcel() {
+    if (!window.yibiao?.duplicateCheck?.exportExcel) {
+      showToast('标书查重结果导出接口尚未加载，请重启应用后重试', 'error');
+      return;
+    }
+    setExportingExcel(true);
+    try {
+      const result = await window.yibiao.duplicateCheck.exportExcel({ signature: currentAnalysisSignature });
+      if (result.canceled) return;
+      if (!result.success || !result.path) {
+        showToast(result.message || '标书查重结果导出失败', 'error');
+        return;
+      }
+      setExportedExcelPath(result.path);
+      showToast(result.message || '标书查重结果已导出', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '标书查重结果导出失败', 'error');
+    } finally {
+      setExportingExcel(false);
+    }
+  }
+
+  async function openExportedExcelFile() {
+    if (!exportedExcelPath) return;
+    try {
+      await window.yibiao.export.openFile(exportedExcelPath);
+      setExportedExcelPath('');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '打开 Excel 文件失败', 'error');
+    }
+  }
+
   const resetFiles = () => {
     if (isAnalysisRunning) {
       showToast('标书查重分析正在运行，请完成后再重置文件', 'info');
@@ -920,6 +962,22 @@ function DuplicateCheckPage() {
   };
 
   const toolbarGroups: FloatingToolbarGroup[] = [
+    ...(step === 'analysis' ? [{
+      id: 'duplicate-check-export',
+      actions: [{
+        id: 'export-excel',
+        label: exportingExcel ? '导出中...' : '导出 Excel',
+        icon: <ToolbarDocumentIcon />,
+        variant: 'success' as const,
+        disabled: isAnalysisRunning || exportingExcel || !hasExportableCurrentResult,
+        tooltip: isAnalysisRunning
+          ? '请等待当前查重任务结束后再导出'
+          : !hasExportableCurrentResult
+            ? '没有当前文件集合对应的可导出结果'
+            : '导出当前元数据、目录、正文和图片查重结果',
+        onClick: () => { void exportDuplicateResultsExcel(); },
+      }],
+    }] : []),
     {
       id: 'duplicate-check-reset',
       actions: [
@@ -1077,6 +1135,20 @@ function DuplicateCheckPage() {
       ) : (
         <DuplicateAnalysisPane activeTab={activeAnalysisTab} onTabChange={setActiveAnalysisTab} metadataAnalysis={metadataAnalysis} outlineAnalysis={outlineAnalysis} contentAnalysis={contentAnalysis} imageAnalysis={imageAnalysis} bidFiles={bidFiles} startingAnalysis={startingAnalysis || analysisTask?.status === 'running'} onRerun={() => startDuplicateAnalysis(true)} />
       )}
+
+      <AppDialog
+        open={Boolean(exportedExcelPath)}
+        onOpenChange={(open) => !open && setExportedExcelPath('')}
+        kicker="导出完成"
+        title="标书查重结果已导出"
+        description={exportedExcelPath ? `文件已保存到：${exportedExcelPath}` : undefined}
+        actions={(
+          <>
+            <button type="button" className="secondary-action" onClick={() => setExportedExcelPath('')}>稍后打开</button>
+            <button type="button" className="primary-action" onClick={() => { void openExportedExcelFile(); }}>打开文件</button>
+          </>
+        )}
+      />
 
       <FloatingToolbar groups={toolbarGroups} label="标书查重工具条" />
     </div>

--- a/client/src/features/rejection-check/exportState.test.cjs
+++ b/client/src/features/rejection-check/exportState.test.cjs
@@ -1,0 +1,56 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const ts = require('typescript');
+
+function loadExportStateModule() {
+  const sourcePath = path.join(__dirname, 'exportState.ts');
+  const source = fs.readFileSync(sourcePath, 'utf-8');
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 },
+  }).outputText;
+  const module = { exports: {} };
+  Function('module', 'exports', 'require', compiled)(module, module.exports, require);
+  return module.exports;
+}
+
+const { hasExportableRejectionResults } = loadExportStateModule();
+
+function result(status, inputSignature, findingCount = 0) {
+  return {
+    status,
+    inputSignature,
+    findings: Array.from({ length: findingCount }, (_, index) => ({ id: String(index) })),
+  };
+}
+
+test('至少一个当前签名结果成功时允许导出零问题报告', () => {
+  assert.equal(hasExportableRejectionResults({
+    rejectionCheckResult: result('idle', 'rejection-current'),
+    typoCheckResult: result('success', 'bid-current'),
+    logicCheckResult: result('idle', 'bid-current'),
+    rejectionInputSignature: 'rejection-current',
+    bidSignature: 'bid-current',
+  }), true);
+});
+
+test('当前签名结果已有 finding 时即使状态错误也允许导出', () => {
+  assert.equal(hasExportableRejectionResults({
+    rejectionCheckResult: result('error', 'rejection-current', 1),
+    typoCheckResult: result('error', 'bid-current'),
+    logicCheckResult: result('idle', 'bid-current'),
+    rejectionInputSignature: 'rejection-current',
+    bidSignature: 'bid-current',
+  }), true);
+});
+
+test('旧签名结果和仅错误空结果不能启用导出', () => {
+  assert.equal(hasExportableRejectionResults({
+    rejectionCheckResult: result('success', 'rejection-old', 2),
+    typoCheckResult: result('error', 'bid-current'),
+    logicCheckResult: result('success', 'bid-old', 1),
+    rejectionInputSignature: 'rejection-current',
+    bidSignature: 'bid-current',
+  }), false);
+});

--- a/client/src/features/rejection-check/exportState.ts
+++ b/client/src/features/rejection-check/exportState.ts
@@ -1,0 +1,29 @@
+import type { LogicCheckResultState, RejectionCheckResultState, TypoCheckResultState } from './types';
+
+type ExportableResultState = RejectionCheckResultState | TypoCheckResultState | LogicCheckResultState;
+
+function isCurrentExportableResult(result: ExportableResultState, expectedSignature: string) {
+  return Boolean(
+    expectedSignature
+    && result.inputSignature === expectedSignature
+    && (result.status === 'success' || result.findings.length > 0),
+  );
+}
+
+export function hasExportableRejectionResults({
+  rejectionCheckResult,
+  typoCheckResult,
+  logicCheckResult,
+  rejectionInputSignature,
+  bidSignature,
+}: {
+  rejectionCheckResult: RejectionCheckResultState;
+  typoCheckResult: TypoCheckResultState;
+  logicCheckResult: LogicCheckResultState;
+  rejectionInputSignature: string;
+  bidSignature: string;
+}) {
+  return isCurrentExportableResult(rejectionCheckResult, rejectionInputSignature)
+    || isCurrentExportableResult(typoCheckResult, bidSignature)
+    || isCurrentExportableResult(logicCheckResult, bidSignature);
+}

--- a/client/src/features/rejection-check/pages/RejectionCheckPage.tsx
+++ b/client/src/features/rejection-check/pages/RejectionCheckPage.tsx
@@ -1,8 +1,9 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { trackPageView } from '../../../shared/analytics/analytics';
-import { AppSwitch, FloatingToolbar, isLibreOfficeRequiredMessage, MarkdownEditor, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
+import { AppDialog, AppSwitch, FloatingToolbar, isLibreOfficeRequiredMessage, MarkdownEditor, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, ToolbarArrowLeftIcon, ToolbarArrowRightIcon, ToolbarDocumentIcon, UploadBoard, UploadEmpty, UploadFilePill, UploadRow, useDocumentParseNotice, useToast } from '../../../shared/ui';
 import type { FloatingToolbarGroup } from '../../../shared/ui';
+import { hasExportableRejectionResults } from '../exportState';
 import type {
   LogicCheckFinding,
   LogicCheckResultState,
@@ -579,6 +580,8 @@ function RejectionCheckPage() {
   const [draftCheckOptions, setDraftCheckOptions] = useState<RejectionCheckOptions>(defaultCheckOptions);
   const [checkConfigDialogOpen, setCheckConfigDialogOpen] = useState(false);
   const [busy, setBusy] = useState<'technical-plan' | 'tender-upload' | 'bid-upload' | 'remove' | null>(null);
+  const [exportingExcel, setExportingExcel] = useState(false);
+  const [exportedExcelPath, setExportedExcelPath] = useState('');
   const [analyticsReady, setAnalyticsReady] = useState(false);
   const hydratedRef = useRef(false);
   const autoStartedSignatureRef = useRef('');
@@ -655,6 +658,13 @@ function RejectionCheckPage() {
   const logicCheckRunning = logicCheckResult.status === 'running';
   const backgroundCheckRunning = checkTask?.status === 'running';
   const checkRunning = rejectionCheckRunning || typoCheckRunning || logicCheckRunning || backgroundCheckRunning;
+  const hasExportableCurrentResult = hasExportableRejectionResults({
+    rejectionCheckResult,
+    typoCheckResult,
+    logicCheckResult,
+    rejectionInputSignature: currentRejectionCheckInputSignature,
+    bidSignature,
+  });
   const documentsLocked = busy !== null || extractionRunning || checkRunning;
   const customCheckItemsDirty = customCheckItemsDraft !== customCheckItems;
   const customCheckItemsDisabled = extractionRunning || checkRunning || customCheckItemsSaving;
@@ -1439,6 +1449,41 @@ function RejectionCheckPage() {
       : prev);
   }
 
+  async function exportCheckResultsExcel() {
+    if (!window.yibiao?.rejectionCheck?.exportExcel) {
+      showToast('废标检查结果导出接口尚未加载，请重启应用后重试', 'error');
+      return;
+    }
+    setExportingExcel(true);
+    try {
+      const result = await window.yibiao.rejectionCheck.exportExcel({
+        rejectionInputSignature: currentRejectionCheckInputSignature,
+        bidSignature,
+      });
+      if (result.canceled) return;
+      if (!result.success || !result.path) {
+        showToast(result.message || '废标检查结果导出失败', 'error');
+        return;
+      }
+      setExportedExcelPath(result.path);
+      showToast(result.message || '废标检查结果已导出', 'success');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '废标检查结果导出失败', 'error');
+    } finally {
+      setExportingExcel(false);
+    }
+  }
+
+  async function openExportedExcelFile() {
+    if (!exportedExcelPath) return;
+    try {
+      await window.yibiao.export.openFile(exportedExcelPath);
+      setExportedExcelPath('');
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : '打开 Excel 文件失败', 'error');
+    }
+  }
+
   function switchStep(nextStep: RejectionCheckStep) {
     if (nextStep !== step && !ensureCustomCheckItemsSaved()) {
       return;
@@ -1728,6 +1773,22 @@ function RejectionCheckPage() {
   }
 
   const toolbarGroups: FloatingToolbarGroup[] = [
+    ...(step === 'results' ? [{
+      id: 'rejection-check-export',
+      actions: [{
+        id: 'export-excel',
+        label: exportingExcel ? '导出中...' : '导出 Excel',
+        icon: <ToolbarDocumentIcon />,
+        variant: 'success' as const,
+        disabled: checkRunning || exportingExcel || !hasExportableCurrentResult,
+        tooltip: checkRunning
+          ? '请等待当前检查结束后再导出'
+          : !hasExportableCurrentResult
+            ? '没有当前检查输入对应的可导出结果'
+            : '导出当前废标项、错别字和逻辑问题',
+        onClick: () => { void exportCheckResultsExcel(); },
+      }],
+    }] : []),
     {
       id: 'rejection-check-reset',
       actions: [
@@ -2170,6 +2231,20 @@ function RejectionCheckPage() {
           </Dialog.Root>
         </>
       )}
+
+      <AppDialog
+        open={Boolean(exportedExcelPath)}
+        onOpenChange={(open) => !open && setExportedExcelPath('')}
+        kicker="导出完成"
+        title="废标检查结果已导出"
+        description={exportedExcelPath ? `文件已保存到：${exportedExcelPath}` : undefined}
+        actions={(
+          <>
+            <button type="button" className="secondary-action" onClick={() => setExportedExcelPath('')}>稍后打开</button>
+            <button type="button" className="primary-action" onClick={() => { void openExportedExcelFile(); }}>打开文件</button>
+          </>
+        )}
+      />
 
       <FloatingToolbar groups={toolbarGroups} label="废标项检查工具条" />
     </div>

--- a/client/src/shared/types/ipc.ts
+++ b/client/src/shared/types/ipc.ts
@@ -53,6 +53,13 @@ export interface WordExportResult {
   warnings?: string[];
 }
 
+export interface CheckResultExportResult {
+  success: boolean;
+  canceled?: boolean;
+  path?: string;
+  message?: string;
+}
+
 export interface RequiredOnlineServiceStatus {
   id: string;
   label: string;
@@ -695,6 +702,7 @@ export interface YibiaoBridge {
     saveUiState: (payload: Partial<Pick<DuplicateCheckWorkspaceState, 'step' | 'activeAnalysisTab'>>) => Promise<void>;
     updateState: (partial: DuplicateCheckWorkspacePatch) => Promise<void>;
     clear: () => Promise<{ success: boolean; message?: string }>;
+    exportExcel: (request: { signature: string }) => Promise<CheckResultExportResult>;
   };
   rejectionCheck: {
     loadState: () => Promise<RejectionCheckWorkspaceState>;
@@ -703,6 +711,7 @@ export interface YibiaoBridge {
     removeDocument: (role: RejectionDocumentRole, documentId?: string) => Promise<void>;
     saveUiState: (payload: Partial<Pick<RejectionCheckWorkspaceState, 'step' | 'activeDocumentTab' | 'activeResultTab' | 'activeCheckResultTab' | 'customCheckItems' | 'checkOptions'>>) => Promise<void>;
     updateState: (partial: RejectionCheckWorkspacePatch) => Promise<void>;
+    exportExcel: (request: { rejectionInputSignature: string; bidSignature: string }) => Promise<CheckResultExportResult>;
     clear: () => Promise<{ success: boolean; message?: string }>;
   };
   templates: {


### PR DESCRIPTION
## 背景

废标检查和标书查重结果已经持久化在工作区 SQLite 中，但缺少对外导出能力，用户无法使用 Excel 对检查结果进行筛选、修改、共享和归档。

本 MR 增加统一的 Main 侧 Excel 导出服务，并在废标检查、标书查重两个结果页面提供导出入口。

Closes #145
Closes #97
Closes #183

## 实现内容

### 统一 Excel 导出服务

新增 `checkResultExportService`，统一负责：

- 从对应 SQLite Store 读取当前权威结果；
- 根据 Renderer 提交的当前签名过滤失效结果；
- 使用 SheetJS 构建 `.xlsx` 工作簿；
- 打开系统保存对话框；
- 写入本地 Excel 文件；
- 处理取消、成功和失败结果；
- 支持中文文件名和 Windows 中文保存路径；
- 自动补充 `.xlsx` 扩展名；
- 清理 XML 不支持的控制字符；
- 对超过 Excel 单元格长度限制的文本进行稳定截断；
- 为详情工作表设置列宽和自动筛选。

Renderer 不生成工作簿，不访问 `fs`、`path` 或 Electron API，也不通过 IPC 传输整份检查结果。

### 废标检查结果导出

在废标检查结果页增加“导出 Excel”操作。

工作簿固定包含：

1. `检查概览`
2. `废标项`
3. `错别字`
4. `逻辑问题`

导出内容包括：

- 投标文件序号和文件名；
- 废标项类型；
- 风险等级；
- 标题、摘要和招标要求；
- 投标证据、风险原因和修改建议；
- 错误文本、建议改正、位置和原文摘录；
- 逻辑问题原文、原因和修改建议。

结果有效性规则与页面保持一致：

- 废标项匹配当前 `rejectionInputSignature`；
- 错别字匹配当前 `bidSignature`；
- 逻辑问题匹配当前 `bidSignature`；
- 旧签名结果不会写入 Excel；
- 检查成功但问题数量为 0 时仍允许导出；
- 已产生 finding 时保留已有结果；
- 仅有失败状态且没有 finding 时不允许导出。

### 标书查重结果导出

在标书查重结果页增加“导出 Excel”操作。

工作簿固定包含：

1. `查重概览`
2. `元数据`
3. `目录重复`
4. `文件相似度`
5. `重复句子`
6. `重复图片`

导出内容包括：

- 元数据动态投标文件列；
- 重复文件和同日文件；
- 重复或相似目录组；
- 各文件目录路径；
- 目录相似度；
- 文件两两综合相似度；
- 标题重合度、路径重合度和顺序相似度；
- 共享目录数量和风险等级；
- 重复句子及各文件出现次数；
- 重复图片 Hash；
- 图片各文件出现次数；
- 图片全部出现位置和前文。

每个分析维度分别匹配当前文件集合签名，签名失效的历史分析不会进入工作簿。

本次只导出系统已有的相似度指标，不新增全文重复率。重复图片不导出客户端内部的 `preview_url` 或 `yibiao-asset://` 地址。

### 页面交互

两个结果页面均在 `FloatingToolbar` 中增加“导出 Excel”按钮。

按钮在以下情况禁用：

- 对应检查或查重任务正在运行；
- 当前正在导出；
- 没有当前签名对应的可导出结果。

交互行为：

- 取消保存时不显示错误提示；
- 导出失败时显示错误 Toast；
- 导出成功时显示成功 Toast 和完成对话框；
- 完成对话框提供“打开文件”和“稍后打开”；
- 打开文件复用现有 `window.yibiao.export.openFile()`。

## IPC 变更

新增通道：

- `rejection-check:export-excel`
- `duplicate-check:export-excel`

两个通道均加入工作区数据库就绪通道列表。

Renderer 只提交：

```ts
// 废标检查
{
  rejectionInputSignature: string;
  bidSignature: string;
}

// 标书查重
{
  signature: string;
}
 ```

 Main 从 Store 重新读取结果并完成签名筛选。

 数据与依赖

 本 MR：

 - 不修改数据库 schema；
 - 不增加 migration；
 - 不增加新的业务状态表；
 - 不建立平行 JSON 或 Excel 缓存；
 - 不修改检查算法；
 - 不修改查重算法；
 - 不修改 AI Prompt；
 - 不修改任务生命周期；
 - 不修改 Analytics 协议；
 - 不新增依赖。

 SQLite 继续作为检查结果的唯一权威存储，Excel 只作为线下查看、修改、共享和归档产物。

 测试

 新增定向测试覆盖：

 - 废标检查四张固定工作表；
 - 标书查重六张固定工作表；
 - 三类废标检查结果字段映射；
 - 投标文件序号和名称映射；
 - 元数据动态文件列；
 - 目录路径和文件归属；
 - 相似度数值和百分比格式；
 - 文件 pairwise 相似度；
 - 重复句子出现次数；
 - 重复图片多文件、多位置展开；
 - 失效签名结果过滤；
 - 成功但零问题或零重复结果；
 - 已产生结果但最终状态为失败的情况；
 - 可选字段缺失；
 - XML 控制字符清理；
 - 超长单元格截断；
 - 取消保存不写文件；
 - 自动补充 .xlsx 扩展名；
 - 真实 XLSX Buffer 写入和重新读取；
 - 两个 IPC 通道的签名请求转发；
 - 两个页面的导出按钮可用状态。

 测试结果：

 ```text
tests 16
pass 16
fail 0
 ```

 验证

 已执行：

 ```powershell
node --check electron\services\checkResultExportService.cjs
node --check electron\ipc\duplicateCheckIpc.cjs
node --check electron\ipc\rejectionCheckIpc.cjs
node --check electron\ipc\index.cjs
node --check electron\preload.cjs
 ```

 ```powershell
node --test electron\services\checkResultExportService.test.cjs electron\ipc\duplicateCheckIpc.test.cjs electron\ipc\rejectionCheckIpc.test.cjs src\features\duplicate-check\exportState.test.cjs src\features\rejection-check\exportState.test.cjs
 ```

 ```powershell
npm run smoke:electron-native
npm run build
 ```

 结果：

 - 所有语法检查通过；
 - 16 个定向测试全部通过；
 - better-sqlite3 Electron 原生模块检查通过；
 - TypeScript 和 Vite 构建通过；
 - 仅有项目既有的 chunk 体积警告。

 手工验收

 已在实际 Electron 客户端验证：

 - 废标检查结果页显示“导出 Excel”入口；
 - 标书查重结果页显示“导出 Excel”入口；
 - 当前成功的零问题、零重复结果仍可导出；
 - 任务运行或结果签名失效时按钮按规则禁用；
 - 导出的 Excel 可正常打开；
 - 保存取消、导出成功、打开文件流程符合预期；
 - 中文保存路径正常。

 影响范围

 涉及：

 - Main Excel 导出服务；
 - 废标检查 IPC、preload 和 Renderer；
 - 标书查重 IPC、preload 和 Renderer；
 - bridge TypeScript 类型；
 - 定向测试。

 不影响：

 - 检查和查重算法；
 - SQLite schema 和现有业务数据；
 - 技术方案、可研报告等其他业务流程；
 - Analytics Worker 和 Dashboard；
 - 现有 Word 导出功能。

## 截图验证
<img width="1920" height="1007" alt="72dc8fc87abf34bcc9ae04020445682e" src="https://github.com/user-attachments/assets/4b1a30a2-7127-431f-a418-77aaf252a85d" />
<img width="1920" height="1007" alt="6da5cbfec2fd6c39fd592ea94bce3b4a" src="https://github.com/user-attachments/assets/67825bd4-7905-4469-8af7-1aab97000d5b" />
<img width="726" height="474" alt="5012eeafb9835e788a73613a5d56c867" src="https://github.com/user-attachments/assets/ad004f53-8b46-425c-a244-ef6d7b8aa544" />
<img width="1920" height="992" alt="0b2e1d1b273a059292e3910dbe7c65a0" src="https://github.com/user-attachments/assets/fa2067c8-2035-4ebb-82e7-a052b8693771" />







