### PR TITLE
feat: 增加知识库全局检索

### DIFF
--- a/client/electron/ipc/index.cjs
+++ b/client/electron/ipc/index.cjs
@@ -161,6 +161,7 @@ const workspaceDatabaseChannels = [
   'rejection-check:export-excel',
   'rejection-check:clear',
   'knowledge-base:list',
+  'knowledge-base:search',
   'knowledge-base:create-folder',
   'knowledge-base:rename-folder',
   'knowledge-base:delete-folder',

--- a/client/electron/ipc/knowledgeBaseIpc.cjs
+++ b/client/electron/ipc/knowledgeBaseIpc.cjs
@@ -2,6 +2,7 @@ const { ipcMain } = require('electron');
 
 function registerKnowledgeBaseIpc({ knowledgeBaseService }) {
   ipcMain.handle('knowledge-base:list', () => knowledgeBaseService.list());
+  ipcMain.handle('knowledge-base:search', (_event, keyword) => knowledgeBaseService.search(keyword));
   ipcMain.handle('knowledge-base:create-folder', (_event, name) => knowledgeBaseService.createFolder(name));
   ipcMain.handle('knowledge-base:rename-folder', (_event, folderId, name) => knowledgeBaseService.renameFolder(folderId, name));
   ipcMain.handle('knowledge-base:reorder-folder', (_event, draggedFolderId, targetFolderId, position) => knowledgeBaseService.reorderFolder(draggedFolderId, targetFolderId, position));

--- a/client/electron/ipc/knowledgeBaseIpc.cjs
+++ b/client/electron/ipc/knowledgeBaseIpc.cjs
@@ -2,7 +2,7 @@ const { ipcMain } = require('electron');
 
 function registerKnowledgeBaseIpc({ knowledgeBaseService }) {
   ipcMain.handle('knowledge-base:list', () => knowledgeBaseService.list());
-  ipcMain.handle('knowledge-base:search', (_event, keyword) => knowledgeBaseService.search(keyword));
+  ipcMain.handle('knowledge-base:search', (_event, request) => knowledgeBaseService.search(request));
   ipcMain.handle('knowledge-base:create-folder', (_event, name) => knowledgeBaseService.createFolder(name));
   ipcMain.handle('knowledge-base:rename-folder', (_event, folderId, name) => knowledgeBaseService.renameFolder(folderId, name));
   ipcMain.handle('knowledge-base:reorder-folder', (_event, draggedFolderId, targetFolderId, position) => knowledgeBaseService.reorderFolder(draggedFolderId, targetFolderId, position));

--- a/client/electron/preload.cjs
+++ b/client/electron/preload.cjs
@@ -150,6 +150,7 @@ const bridge = {
   },
   knowledgeBase: {
     list: () => ipcRenderer.invoke('knowledge-base:list'),
+    search: (keyword) => ipcRenderer.invoke('knowledge-base:search', keyword),
     createFolder: (name) => ipcRenderer.invoke('knowledge-base:create-folder', name),
     renameFolder: (folderId, name) => ipcRenderer.invoke('knowledge-base:rename-folder', folderId, name),
     reorderFolder: (draggedFolderId, targetFolderId, position) => ipcRenderer.invoke('knowledge-base:reorder-folder', draggedFolderId, targetFolderId, position),

--- a/client/electron/preload.cjs
+++ b/client/electron/preload.cjs
@@ -150,7 +150,7 @@ const bridge = {
   },
   knowledgeBase: {
     list: () => ipcRenderer.invoke('knowledge-base:list'),
-    search: (keyword) => ipcRenderer.invoke('knowledge-base:search', keyword),
+    search: (request) => ipcRenderer.invoke('knowledge-base:search', request),
     createFolder: (name) => ipcRenderer.invoke('knowledge-base:create-folder', name),
     renameFolder: (folderId, name) => ipcRenderer.invoke('knowledge-base:rename-folder', folderId, name),
     reorderFolder: (draggedFolderId, targetFolderId, position) => ipcRenderer.invoke('knowledge-base:reorder-folder', draggedFolderId, targetFolderId, position),

--- a/client/electron/services/knowledgeBaseService.cjs
+++ b/client/electron/services/knowledgeBaseService.cjs
@@ -2080,6 +2080,9 @@ function createKnowledgeBaseService({ app, aiService, configStore, knowledgeBase
     list() {
       return knowledgeBaseStore.list();
     },
+    search(keyword) {
+      return knowledgeBaseStore.search(keyword);
+    },
 
     createFolder(name) {
       return knowledgeBaseStore.createFolder(name);

--- a/client/electron/services/knowledgeBaseService.cjs
+++ b/client/electron/services/knowledgeBaseService.cjs
@@ -2080,8 +2080,8 @@ function createKnowledgeBaseService({ app, aiService, configStore, knowledgeBase
     list() {
       return knowledgeBaseStore.list();
     },
-    search(keyword) {
-      return knowledgeBaseStore.search(keyword);
+    search(request) {
+      return knowledgeBaseStore.search(request);
     },
 
     createFolder(name) {

--- a/client/electron/services/knowledgeBaseStore.cjs
+++ b/client/electron/services/knowledgeBaseStore.cjs
@@ -253,6 +253,82 @@ function createKnowledgeBaseStore({ app, db }) {
     return { folders, documents };
   }
 
+  function search(keyword) {
+    const normalizedKeyword = String(keyword || '').trim();
+    if (!normalizedKeyword) return [];
+
+    const lowerKeyword = normalizedKeyword.toLocaleLowerCase();
+    const rows = db.prepare(`
+      SELECT d.document_id, d.folder_id, d.file_name, f.name AS folder_name,
+             i.item_id, i.title, i.resume, i.content
+      FROM knowledge_items i
+      INNER JOIN knowledge_documents d ON d.document_id = i.document_id
+      INNER JOIN knowledge_folders f ON f.folder_id = d.folder_id
+      WHERE d.status = 'success'
+        AND (
+          instr(lower(COALESCE(d.file_name, '')), lower(?)) > 0
+          OR instr(lower(COALESCE(i.title, '')), lower(?)) > 0
+          OR instr(lower(COALESCE(i.resume, '')), lower(?)) > 0
+          OR instr(lower(COALESCE(i.content, '')), lower(?)) > 0
+        )
+      ORDER BY
+        CASE
+          WHEN instr(lower(COALESCE(i.title, '')), lower(?)) > 0 THEN 0
+          WHEN instr(lower(COALESCE(i.resume, '')), lower(?)) > 0 THEN 1
+          WHEN instr(lower(COALESCE(i.content, '')), lower(?)) > 0 THEN 2
+          WHEN instr(lower(COALESCE(d.file_name, '')), lower(?)) > 0 THEN 3
+          ELSE 4
+        END,
+        d.updated_at DESC, i.sort_order ASC, i.id ASC
+      LIMIT 100
+    `).all(
+      lowerKeyword,
+      lowerKeyword,
+      lowerKeyword,
+      lowerKeyword,
+      lowerKeyword,
+      lowerKeyword,
+      lowerKeyword,
+      lowerKeyword,
+    );
+
+    const createSnippet = (value) => {
+      const text = String(value || '').replace(/\s+/g, ' ').trim();
+      if (!text) return '';
+      const matchIndex = text.toLocaleLowerCase().indexOf(lowerKeyword);
+      if (matchIndex < 0) return text.slice(0, 180);
+      const contextLength = 180;
+      const start = Math.max(0, matchIndex - Math.floor((contextLength - normalizedKeyword.length) / 2));
+      const end = Math.min(text.length, start + contextLength);
+      return `${start > 0 ? '…' : ''}${text.slice(start, end)}${end < text.length ? '…' : ''}`;
+    };
+
+    return rows.map((row) => {
+      const titleMatched = String(row.title || '').toLocaleLowerCase().includes(lowerKeyword);
+      const resumeMatched = String(row.resume || '').toLocaleLowerCase().includes(lowerKeyword);
+      const contentMatched = String(row.content || '').toLocaleLowerCase().includes(lowerKeyword);
+      const matchField = titleMatched ? 'title' : resumeMatched ? 'resume' : contentMatched ? 'content' : 'file_name';
+      const snippetSource = matchField === 'title'
+        ? row.title
+        : matchField === 'resume'
+          ? row.resume
+          : matchField === 'content'
+            ? row.content
+            : row.file_name;
+      return {
+        document_id: row.document_id,
+        folder_id: row.folder_id,
+        folder_name: row.folder_name,
+        file_name: row.file_name,
+        item_id: row.item_id,
+        title: row.title,
+        resume: row.resume,
+        snippet: createSnippet(snippetSource),
+        match_field: matchField,
+      };
+    });
+  }
+
   function recoverInterruptedDocuments(activeDocumentIds = []) {
     const activeIds = new Set((Array.isArray(activeDocumentIds) ? activeDocumentIds : []).map((id) => String(id || '')).filter(Boolean));
     const legacyRows = db.prepare(`
@@ -1135,6 +1211,7 @@ function createKnowledgeBaseStore({ app, db }) {
     readItems,
     readAnalysis,
     getOutlineReferences,
+    search,
     resolvePath,
   };
 }

--- a/client/electron/services/knowledgeBaseStore.cjs
+++ b/client/electron/services/knowledgeBaseStore.cjs
@@ -253,44 +253,44 @@ function createKnowledgeBaseStore({ app, db }) {
     return { folders, documents };
   }
 
-  function search(keyword) {
+  function search({ keyword, page }) {
+    const pageSize = 100;
     const normalizedKeyword = String(keyword || '').trim();
-    if (!normalizedKeyword) return [];
+    if (!normalizedKeyword) return { items: [], total: 0, page: 1, pageSize };
 
     const lowerKeyword = normalizedKeyword.toLocaleLowerCase();
-    const rows = db.prepare(`
-      SELECT d.document_id, d.folder_id, d.file_name, f.name AS folder_name,
-             i.item_id, i.title, i.resume, i.content
+    const matchSql = `
       FROM knowledge_items i
       INNER JOIN knowledge_documents d ON d.document_id = i.document_id
       INNER JOIN knowledge_folders f ON f.folder_id = d.folder_id
       WHERE d.status = 'success'
         AND (
-          instr(lower(COALESCE(d.file_name, '')), lower(?)) > 0
-          OR instr(lower(COALESCE(i.title, '')), lower(?)) > 0
-          OR instr(lower(COALESCE(i.resume, '')), lower(?)) > 0
-          OR instr(lower(COALESCE(i.content, '')), lower(?)) > 0
+          instr(lower(COALESCE(d.file_name, '')), @keyword) > 0
+          OR instr(lower(COALESCE(i.title, '')), @keyword) > 0
+          OR instr(lower(COALESCE(i.resume, '')), @keyword) > 0
+          OR instr(lower(COALESCE(i.content, '')), @keyword) > 0
         )
+    `;
+    const { rows, total, currentPage } = db.transaction(() => {
+      const { total } = db.prepare(`SELECT COUNT(*) AS total ${matchSql}`).get({ keyword: lowerKeyword });
+      const currentPage = Math.min(page, Math.max(1, Math.ceil(total / pageSize)));
+      const rows = total ? db.prepare(`
+      SELECT d.document_id, d.folder_id, d.file_name, f.name AS folder_name,
+             i.item_id, i.title, i.resume, i.content
+      ${matchSql}
       ORDER BY
         CASE
-          WHEN instr(lower(COALESCE(i.title, '')), lower(?)) > 0 THEN 0
-          WHEN instr(lower(COALESCE(i.resume, '')), lower(?)) > 0 THEN 1
-          WHEN instr(lower(COALESCE(i.content, '')), lower(?)) > 0 THEN 2
-          WHEN instr(lower(COALESCE(d.file_name, '')), lower(?)) > 0 THEN 3
+          WHEN instr(lower(COALESCE(i.title, '')), @keyword) > 0 THEN 0
+          WHEN instr(lower(COALESCE(i.resume, '')), @keyword) > 0 THEN 1
+          WHEN instr(lower(COALESCE(i.content, '')), @keyword) > 0 THEN 2
+          WHEN instr(lower(COALESCE(d.file_name, '')), @keyword) > 0 THEN 3
           ELSE 4
         END,
         d.updated_at DESC, i.sort_order ASC, i.id ASC
-      LIMIT 100
-    `).all(
-      lowerKeyword,
-      lowerKeyword,
-      lowerKeyword,
-      lowerKeyword,
-      lowerKeyword,
-      lowerKeyword,
-      lowerKeyword,
-      lowerKeyword,
-    );
+      LIMIT @limit OFFSET @offset
+      `).all({ keyword: lowerKeyword, limit: pageSize, offset: (currentPage - 1) * pageSize }) : [];
+      return { rows, total, currentPage };
+    })();
 
     const createSnippet = (value) => {
       const text = String(value || '').replace(/\s+/g, ' ').trim();
@@ -303,7 +303,7 @@ function createKnowledgeBaseStore({ app, db }) {
       return `${start > 0 ? '…' : ''}${text.slice(start, end)}${end < text.length ? '…' : ''}`;
     };
 
-    return rows.map((row) => {
+    const items = rows.map((row) => {
       const titleMatched = String(row.title || '').toLocaleLowerCase().includes(lowerKeyword);
       const resumeMatched = String(row.resume || '').toLocaleLowerCase().includes(lowerKeyword);
       const contentMatched = String(row.content || '').toLocaleLowerCase().includes(lowerKeyword);
@@ -327,6 +327,7 @@ function createKnowledgeBaseStore({ app, db }) {
         match_field: matchField,
       };
     });
+    return { items, total, page: currentPage, pageSize };
   }
 
   function recoverInterruptedDocuments(activeDocumentIds = []) {

--- a/client/electron/services/knowledgeBaseStore.search.test.cjs
+++ b/client/electron/services/knowledgeBaseStore.search.test.cjs
@@ -1,0 +1,84 @@
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const Database = require('better-sqlite3');
+const { createKnowledgeBaseStore } = require('./knowledgeBaseStore.cjs');
+
+function createFixture() {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE knowledge_folders (
+      folder_id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE knowledge_documents (
+      document_id TEXT PRIMARY KEY,
+      folder_id TEXT NOT NULL,
+      file_name TEXT NOT NULL,
+      status TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE knowledge_items (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      document_id TEXT NOT NULL,
+      item_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      resume TEXT NOT NULL,
+      content TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  db.prepare('INSERT INTO knowledge_folders VALUES (?, ?, 0, ?, ?)').run('folder-a', '项目资料', '2026-01-01', '2026-01-01');
+  db.prepare('INSERT INTO knowledge_folders VALUES (?, ?, 1, ?, ?)').run('folder-b', '历史标书', '2026-01-01', '2026-01-01');
+  db.prepare('INSERT INTO knowledge_documents VALUES (?, ?, ?, ?, 0, ?)').run('doc-a', 'folder-a', '实施方案.docx', 'success', '2026-02-01');
+  db.prepare('INSERT INTO knowledge_documents VALUES (?, ?, ?, ?, 0, ?)').run('doc-b', 'folder-b', '运维说明.docx', 'success', '2026-01-15');
+  db.prepare('INSERT INTO knowledge_documents VALUES (?, ?, ?, ?, 0, ?)').run('doc-c', 'folder-b', '处理中.docx', 'matching', '2026-03-01');
+  const insertItem = db.prepare('INSERT INTO knowledge_items (document_id, item_id, title, resume, content, sort_order) VALUES (?, ?, ?, ?, ?, ?)');
+  insertItem.run('doc-a', 'A-1', '质量保证体系', '覆盖质量目标和检查机制', '方案正文包含质量保证关键字。', 0);
+  insertItem.run('doc-b', 'B-1', '运维流程', '提供质量保证服务', '正文不含目标词。', 0);
+  insertItem.run('doc-c', 'C-1', '质量保证草稿', '处理中内容', '不应被检索', 0);
+  const app = { getPath: () => path.join(os.tmpdir(), 'knowledge-search-test') };
+  return { db, store: createKnowledgeBaseStore({ app, db }) };
+}
+
+test('search returns a successful document when its file name matches', () => {
+  const { db, store } = createFixture();
+  try {
+    const results = store.search('实施方案');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].match_field, 'file_name');
+    assert.equal(results[0].file_name, '实施方案.docx');
+  } finally {
+    db.close();
+  }
+});
+
+test('search returns matches across successful knowledge documents with title matches first', () => {
+  const { db, store } = createFixture();
+  try {
+    const results = store.search('质量保证');
+    assert.deepEqual(results.map((item) => item.item_id), ['A-1', 'B-1']);
+    assert.equal(results[0].match_field, 'title');
+    assert.equal(results[0].folder_name, '项目资料');
+    assert.equal(results[1].match_field, 'resume');
+    assert.match(results[1].snippet, /质量保证/);
+  } finally {
+    db.close();
+  }
+});
+
+
+test('search ignores unfinished documents and blank keywords', () => {
+  const { db, store } = createFixture();
+  try {
+    assert.equal(store.search('草稿').length, 0);
+    assert.deepEqual(store.search('  '), []);
+  } finally {
+    db.close();
+  }
+});

--- a/client/electron/services/knowledgeBaseStore.search.test.cjs
+++ b/client/electron/services/knowledgeBaseStore.search.test.cjs
@@ -5,32 +5,21 @@ const test = require('node:test');
 const Database = require('better-sqlite3');
 const { createKnowledgeBaseStore } = require('./knowledgeBaseStore.cjs');
 
-function createFixture() {
+function createFixture(t) {
   const db = new Database(':memory:');
+  t.after(() => db.close());
   db.exec(`
     CREATE TABLE knowledge_folders (
-      folder_id TEXT PRIMARY KEY,
-      name TEXT NOT NULL,
-      sort_order INTEGER NOT NULL DEFAULT 0,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
+      folder_id TEXT PRIMARY KEY, name TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
     );
     CREATE TABLE knowledge_documents (
-      document_id TEXT PRIMARY KEY,
-      folder_id TEXT NOT NULL,
-      file_name TEXT NOT NULL,
-      status TEXT NOT NULL,
-      sort_order INTEGER NOT NULL DEFAULT 0,
-      updated_at TEXT NOT NULL
+      document_id TEXT PRIMARY KEY, folder_id TEXT NOT NULL, file_name TEXT NOT NULL,
+      status TEXT NOT NULL, sort_order INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL
     );
     CREATE TABLE knowledge_items (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      document_id TEXT NOT NULL,
-      item_id TEXT NOT NULL,
-      title TEXT NOT NULL,
-      resume TEXT NOT NULL,
-      content TEXT NOT NULL,
-      sort_order INTEGER NOT NULL DEFAULT 0
+      id INTEGER PRIMARY KEY AUTOINCREMENT, document_id TEXT NOT NULL, item_id TEXT NOT NULL,
+      title TEXT NOT NULL, resume TEXT NOT NULL, content TEXT NOT NULL, sort_order INTEGER NOT NULL DEFAULT 0
     );
   `);
   db.prepare('INSERT INTO knowledge_folders VALUES (?, ?, 0, ?, ?)').run('folder-a', '项目资料', '2026-01-01', '2026-01-01');
@@ -42,43 +31,67 @@ function createFixture() {
   insertItem.run('doc-a', 'A-1', '质量保证体系', '覆盖质量目标和检查机制', '方案正文包含质量保证关键字。', 0);
   insertItem.run('doc-b', 'B-1', '运维流程', '提供质量保证服务', '正文不含目标词。', 0);
   insertItem.run('doc-c', 'C-1', '质量保证草稿', '处理中内容', '不应被检索', 0);
-  const app = { getPath: () => path.join(os.tmpdir(), 'knowledge-search-test') };
-  return { db, store: createKnowledgeBaseStore({ app, db }) };
+  const app = { getPath: () => path.join(os.tmpdir(), '知识库分页回归') };
+  return { db, insertItem, store: createKnowledgeBaseStore({ app, db }) };
 }
 
-test('search returns a successful document when its file name matches', () => {
-  const { db, store } = createFixture();
-  try {
-    const results = store.search('实施方案');
-    assert.equal(results.length, 1);
-    assert.equal(results[0].match_field, 'file_name');
-    assert.equal(results[0].file_name, '实施方案.docx');
-  } finally {
-    db.close();
-  }
+test('search preserves filename, title, resume and content matches and their priority', (t) => {
+  const { store, insertItem } = createFixture(t);
+  const byFilename = store.search({ keyword: '实施方案', page: 1 });
+  assert.equal(byFilename.total, 1);
+  assert.equal(byFilename.items[0].match_field, 'file_name');
+  assert.equal(byFilename.items[0].file_name, '实施方案.docx');
+  insertItem.run('doc-b', 'B-2', '检查措施', '专项检查', '质量保证正文命中', 1);
+  const result = store.search({ keyword: '质量保证', page: 1 });
+  assert.equal(result.total, 3);
+  assert.deepEqual(result.items.map((item) => item.item_id), ['A-1', 'B-1', 'B-2']);
+  assert.deepEqual(result.items.map((item) => item.match_field), ['title', 'resume', 'content']);
+  assert.equal(result.items[0].folder_name, '项目资料');
+  assert.match(result.items[1].snippet, /质量保证/);
+  assert.match(result.items[2].snippet, /质量保证/);
 });
 
-test('search returns matches across successful knowledge documents with title matches first', () => {
-  const { db, store } = createFixture();
-  try {
-    const results = store.search('质量保证');
-    assert.deepEqual(results.map((item) => item.item_id), ['A-1', 'B-1']);
-    assert.equal(results[0].match_field, 'title');
-    assert.equal(results[0].folder_name, '项目资料');
-    assert.equal(results[1].match_field, 'resume');
-    assert.match(results[1].snippet, /质量保证/);
-  } finally {
-    db.close();
-  }
+test('search ignores unfinished documents and blank keywords', (t) => {
+  const { store } = createFixture(t);
+  assert.deepEqual(store.search({ keyword: '草稿', page: 1 }), { items: [], total: 0, page: 1, pageSize: 100 });
+  assert.deepEqual(store.search({ keyword: '  ', page: 3 }), { items: [], total: 0, page: 1, pageSize: 100 });
 });
 
+test('all 235 filename matches remain accessible across documents without duplicates or omissions', (t) => {
+  const { db, store, insertItem } = createFixture(t);
+  db.exec("DELETE FROM knowledge_items; UPDATE knowledge_documents SET file_name = '公共资料.docx'");
+  const expected = [];
+  db.transaction(() => {
+    for (let index = 0; index < 235; index += 1) {
+      const itemId = `item-${index}`;
+      expected.push(itemId);
+      insertItem.run(index < 150 ? 'doc-a' : 'doc-b', itemId, '条目', '摘要', '正文', index);
+    }
+    insertItem.run('doc-c', 'unfinished', '条目', '摘要', '正文', 0);
+  })();
+  const pages = [1, 2, 3].map((page) => store.search({ keyword: '公共资料', page }));
+  assert.deepEqual(pages.map((page) => page.total), [235, 235, 235]);
+  assert.deepEqual(pages.map((page) => page.items.length), [100, 100, 35]);
+  assert.deepEqual(pages.flatMap((page) => page.items.map((item) => item.item_id)), expected);
+  assert.equal(pages[1].items[50].document_id, 'doc-b');
+  assert.deepEqual(store.search({ keyword: '公共资料', page: 2 }), pages[1]);
+});
 
-test('search ignores unfinished documents and blank keywords', () => {
-  const { db, store } = createFixture();
-  try {
-    assert.equal(store.search('草稿').length, 0);
-    assert.deepEqual(store.search('  '), []);
-  } finally {
-    db.close();
+test('page boundaries follow 100 and 101 matches and clamp after deletion including an empty library', (t) => {
+  const { db, store, insertItem } = createFixture(t);
+  db.exec('DELETE FROM knowledge_items');
+  for (let index = 0; index < 101; index += 1) {
+    insertItem.run('doc-a', `boundary-${index}`, '边界', '摘要', '正文', index);
   }
+  const second = store.search({ keyword: '边界', page: 2 });
+  assert.equal(second.total, 101);
+  assert.equal(second.page, 2);
+  assert.deepEqual(second.items.map((item) => item.item_id), ['boundary-100']);
+  db.prepare('DELETE FROM knowledge_items WHERE item_id = ?').run('boundary-100');
+  const clamped = store.search({ keyword: '边界', page: 2 });
+  assert.equal(clamped.total, 100);
+  assert.equal(clamped.page, 1);
+  assert.equal(clamped.items.length, 100);
+  db.exec('DELETE FROM knowledge_items');
+  assert.deepEqual(store.search({ keyword: '边界', page: 2 }), { items: [], total: 0, page: 1, pageSize: 100 });
 });

--- a/client/src/features/knowledge-base/pages/KnowledgeBasePage.tsx
+++ b/client/src/features/knowledge-base/pages/KnowledgeBasePage.tsx
@@ -2,7 +2,7 @@ import { Profiler, startTransition, useEffect, useLayoutEffect, useMemo, useRef,
 import * as Dialog from '@radix-ui/react-dialog';
 import { trackPageView } from '../../../shared/analytics/analytics';
 import { AppDialog, InlineSpinner, isLibreOfficeRequiredMessage, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, useDocumentParseNotice, useToast } from '../../../shared/ui';
-import type { KnowledgeAnalysisSnapshot, KnowledgeBaseIndex, KnowledgeDocument, KnowledgeItem } from '../types';
+import type { KnowledgeAnalysisSnapshot, KnowledgeBaseIndex, KnowledgeBaseSearchResult, KnowledgeDocument, KnowledgeItem } from '../types';
 
 declare global {
   interface Window {
@@ -323,6 +323,11 @@ function KnowledgeBasePage() {
     | null
   >(null);
   const [deletingConfirm, setDeletingConfirm] = useState(false);
+  const [searchKeyword, setSearchKeyword] = useState('');
+  const [submittedSearchKeyword, setSubmittedSearchKeyword] = useState('');
+  const [searchResults, setSearchResults] = useState<KnowledgeBaseSearchResult[]>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const searchRequestIdRef = useRef(0);
   const autoMatchingIdsRef = useRef(new Set<string>());
   const documentParseNoticeIdsRef = useRef(new Set<string>());
   const viewerRequestIdRef = useRef(0);
@@ -568,6 +573,52 @@ function KnowledgeBasePage() {
       }
     }
   };
+
+  const runGlobalSearch = async () => {
+    const keyword = searchKeyword.trim();
+    if (!keyword) {
+      searchRequestIdRef.current += 1;
+      setSubmittedSearchKeyword('');
+      setSearchResults([]);
+      return;
+    }
+
+    const requestId = searchRequestIdRef.current + 1;
+    searchRequestIdRef.current = requestId;
+    setSubmittedSearchKeyword(keyword);
+    setSearchResults([]);
+    setSearchLoading(true);
+    try {
+      const results = await window.yibiao?.knowledgeBase.search(keyword);
+      if (searchRequestIdRef.current !== requestId) return;
+      setSearchResults(results || []);
+    } catch (error) {
+      if (searchRequestIdRef.current === requestId) {
+        showToast(error instanceof Error ? error.message : '知识库检索失败', 'error');
+      }
+    } finally {
+      if (searchRequestIdRef.current === requestId) setSearchLoading(false);
+    }
+  };
+
+  const clearGlobalSearch = () => {
+    searchRequestIdRef.current += 1;
+    setSearchKeyword('');
+    setSubmittedSearchKeyword('');
+    setSearchResults([]);
+    setSearchLoading(false);
+  };
+
+  const openSearchResult = async (result: KnowledgeBaseSearchResult) => {
+    const document = index.documents.find((item) => item.id === result.document_id);
+    if (!document) {
+      showToast('对应知识文档已不存在，请重新检索', 'info');
+      return;
+    }
+    setActiveFolderId(result.folder_id);
+    await openDocument(document, 'items');
+  };
+
 
   const createFolder = async () => {
     const name = newFolderName.trim();
@@ -897,6 +948,28 @@ function KnowledgeBasePage() {
         </div>
       </section>
 
+      <form
+        className="knowledge-global-search"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void runGlobalSearch();
+        }}
+      >
+        <label htmlFor="knowledge-global-search-input">全库检索</label>
+        <div className="knowledge-global-search-controls">
+          <input
+            id="knowledge-global-search-input"
+            value={searchKeyword}
+            onChange={(event) => setSearchKeyword(event.target.value)}
+            placeholder="输入知识关键字，检索所有已完成文档"
+          />
+          <button type="submit" className="primary-action" disabled={searchLoading || !searchKeyword.trim()}>
+            {searchLoading ? '检索中...' : '检索'}
+          </button>
+          {submittedSearchKeyword && <button type="button" className="secondary-action" onClick={clearGlobalSearch}>返回文件夹</button>}
+        </div>
+      </form>
+
       {showCreateFolder && (
         <form
           className="knowledge-create-folder-bar"
@@ -925,7 +998,16 @@ function KnowledgeBasePage() {
         </form>
       )}
 
-      <section className="knowledge-layout">
+      {submittedSearchKeyword && (
+        <KnowledgeSearchResults
+          keyword={submittedSearchKeyword}
+          results={searchResults}
+          loading={searchLoading}
+          onOpenResult={(result) => { void openSearchResult(result); }}
+        />
+      )}
+
+      {!submittedSearchKeyword && <section className="knowledge-layout">
         <aside className="knowledge-folder-panel">
           <div className="knowledge-panel-head">
             <strong>文件夹</strong>
@@ -1061,7 +1143,7 @@ function KnowledgeBasePage() {
             </div>
           )}
         </main>
-        </section>
+        </section>}
       </div>
 
       <AppDialog
@@ -1527,3 +1609,48 @@ function mergeDocuments(prev: KnowledgeDocument[], next: KnowledgeDocument[]) {
 }
 
 export default KnowledgeBasePage;
+
+interface KnowledgeSearchResultsProps {
+  keyword: string;
+  results: KnowledgeBaseSearchResult[];
+  loading: boolean;
+  onOpenResult: (result: KnowledgeBaseSearchResult) => void;
+}
+
+function KnowledgeSearchResults({ keyword, results, loading, onOpenResult }: KnowledgeSearchResultsProps) {
+  return (
+    <section className="knowledge-search-panel">
+      <div className="knowledge-panel-head">
+        <strong>“{keyword}”的检索结果</strong>
+        <span>{loading ? '正在检索' : `${results.length} 条知识`}</span>
+      </div>
+      {loading ? (
+        <div className="knowledge-empty-box large">
+          <InlineSpinner />
+          <strong>正在检索全部知识库...</strong>
+          <p>检索完成后会显示对应文档和知识片段。</p>
+        </div>
+      ) : results.length ? (
+        <div className="knowledge-search-result-list">
+          {results.map((result) => (
+            <article className="knowledge-search-result-card" key={`${result.document_id}:${result.item_id}`}>
+              <div className="knowledge-search-result-path">
+                <span>{result.folder_name}</span>
+                <span aria-hidden="true">/</span>
+                <strong>{result.file_name}</strong>
+              </div>
+              <h3>{result.title}</h3>
+              <p>{result.snippet || result.resume || '该条目暂无可显示片段'}</p>
+              <button type="button" className="knowledge-item-source-action" onClick={() => onOpenResult(result)}>打开知识条目</button>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <div className="knowledge-empty-box large">
+          <strong>没有找到相关知识</strong>
+          <p>请更换关键字，或确认相关文档已经完成知识整理。</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/features/knowledge-base/pages/KnowledgeBasePage.tsx
+++ b/client/src/features/knowledge-base/pages/KnowledgeBasePage.tsx
@@ -2,7 +2,7 @@ import { Profiler, startTransition, useEffect, useLayoutEffect, useMemo, useRef,
 import * as Dialog from '@radix-ui/react-dialog';
 import { trackPageView } from '../../../shared/analytics/analytics';
 import { AppDialog, InlineSpinner, isLibreOfficeRequiredMessage, MarkdownFullscreenViewer, MarkdownRenderer, ProgressBar, useDocumentParseNotice, useToast } from '../../../shared/ui';
-import type { KnowledgeAnalysisSnapshot, KnowledgeBaseIndex, KnowledgeBaseSearchResult, KnowledgeDocument, KnowledgeItem } from '../types';
+import type { KnowledgeAnalysisSnapshot, KnowledgeBaseIndex, KnowledgeBaseSearchPage, KnowledgeBaseSearchResult, KnowledgeDocument, KnowledgeItem } from '../types';
 
 declare global {
   interface Window {
@@ -325,7 +325,8 @@ function KnowledgeBasePage() {
   const [deletingConfirm, setDeletingConfirm] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [submittedSearchKeyword, setSubmittedSearchKeyword] = useState('');
-  const [searchResults, setSearchResults] = useState<KnowledgeBaseSearchResult[]>([]);
+  const [searchPage, setSearchPage] = useState<KnowledgeBaseSearchPage | null>(null);
+  const [searchError, setSearchError] = useState('');
   const [searchLoading, setSearchLoading] = useState(false);
   const searchRequestIdRef = useRef(0);
   const autoMatchingIdsRef = useRef(new Set<string>());
@@ -574,38 +575,42 @@ function KnowledgeBasePage() {
     }
   };
 
-  const runGlobalSearch = async () => {
-    const keyword = searchKeyword.trim();
-    if (!keyword) {
-      searchRequestIdRef.current += 1;
-      setSubmittedSearchKeyword('');
-      setSearchResults([]);
-      return;
-    }
-
-    const requestId = searchRequestIdRef.current + 1;
-    searchRequestIdRef.current = requestId;
-    setSubmittedSearchKeyword(keyword);
-    setSearchResults([]);
+  const fetchGlobalSearch = async (keyword: string, page: number) => {
+    const requestId = ++searchRequestIdRef.current;
+    setSearchError('');
     setSearchLoading(true);
     try {
-      const results = await window.yibiao?.knowledgeBase.search(keyword);
+      const result = await window.yibiao.knowledgeBase.search({ keyword, page });
       if (searchRequestIdRef.current !== requestId) return;
-      setSearchResults(results || []);
+      setSearchPage(result);
     } catch (error) {
       if (searchRequestIdRef.current === requestId) {
-        showToast(error instanceof Error ? error.message : '知识库检索失败', 'error');
+        const message = error instanceof Error ? error.message : '知识库检索失败';
+        setSearchError(message);
+        showToast(message, 'error');
       }
     } finally {
       if (searchRequestIdRef.current === requestId) setSearchLoading(false);
     }
   };
 
+  const runGlobalSearch = async () => {
+    const keyword = searchKeyword.trim();
+    if (!keyword) {
+      clearGlobalSearch();
+      return;
+    }
+    setSubmittedSearchKeyword(keyword);
+    setSearchPage(null);
+    await fetchGlobalSearch(keyword, 1);
+  };
+
   const clearGlobalSearch = () => {
     searchRequestIdRef.current += 1;
     setSearchKeyword('');
     setSubmittedSearchKeyword('');
-    setSearchResults([]);
+    setSearchPage(null);
+    setSearchError('');
     setSearchLoading(false);
   };
 
@@ -1001,7 +1006,9 @@ function KnowledgeBasePage() {
       {submittedSearchKeyword && (
         <KnowledgeSearchResults
           keyword={submittedSearchKeyword}
-          results={searchResults}
+          resultPage={searchPage}
+          error={searchError}
+          onPageChange={(page) => { void fetchGlobalSearch(submittedSearchKeyword, page); }}
           loading={searchLoading}
           onOpenResult={(result) => { void openSearchResult(result); }}
         />
@@ -1612,27 +1619,31 @@ export default KnowledgeBasePage;
 
 interface KnowledgeSearchResultsProps {
   keyword: string;
-  results: KnowledgeBaseSearchResult[];
+  resultPage: KnowledgeBaseSearchPage | null;
+  error: string;
   loading: boolean;
+  onPageChange: (page: number) => void;
   onOpenResult: (result: KnowledgeBaseSearchResult) => void;
 }
 
-function KnowledgeSearchResults({ keyword, results, loading, onOpenResult }: KnowledgeSearchResultsProps) {
+function KnowledgeSearchResults({ keyword, resultPage, error, loading, onPageChange, onOpenResult }: KnowledgeSearchResultsProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = 0;
+  }, [resultPage]);
+  const results = resultPage?.items || [];
+  const totalPages = resultPage ? Math.max(1, Math.ceil(resultPage.total / resultPage.pageSize)) : 1;
+
   return (
-    <section className="knowledge-search-panel">
+    <section className="knowledge-search-panel" aria-busy={loading}>
       <div className="knowledge-panel-head">
         <strong>“{keyword}”的检索结果</strong>
-        <span>{loading ? '正在检索' : `${results.length} 条知识`}</span>
+        <span aria-live="polite">{loading ? '正在检索' : resultPage ? `共 ${resultPage.total} 条知识` : '检索失败'}</span>
       </div>
-      {loading ? (
-        <div className="knowledge-empty-box large">
-          <InlineSpinner />
-          <strong>正在检索全部知识库...</strong>
-          <p>检索完成后会显示对应文档和知识片段。</p>
-        </div>
-      ) : results.length ? (
-        <div className="knowledge-search-result-list">
-          {results.map((result) => (
+      {resultPage ? (
+        <div className="knowledge-search-result-list" ref={listRef}>
+          {error && <p role="alert">检索失败，仍显示上次成功的结果。请重新检索或翻页。{error}</p>}
+          {results.length ? results.map((result) => (
             <article className="knowledge-search-result-card" key={`${result.document_id}:${result.item_id}`}>
               <div className="knowledge-search-result-path">
                 <span>{result.folder_name}</span>
@@ -1643,12 +1654,32 @@ function KnowledgeSearchResults({ keyword, results, loading, onOpenResult }: Kno
               <p>{result.snippet || result.resume || '该条目暂无可显示片段'}</p>
               <button type="button" className="knowledge-item-source-action" onClick={() => onOpenResult(result)}>打开知识条目</button>
             </article>
-          ))}
+          )) : (
+            <div className="knowledge-empty-box large">
+              <strong>没有找到相关知识</strong>
+              <p>请更换关键字，或确认相关文档已经完成知识整理。</p>
+            </div>
+          )}
         </div>
       ) : (
         <div className="knowledge-empty-box large">
-          <strong>没有找到相关知识</strong>
-          <p>请更换关键字，或确认相关文档已经完成知识整理。</p>
+          {loading ? <>
+            <InlineSpinner />
+            <strong>正在检索全部知识库...</strong>
+            <p>检索完成后会显示对应文档和知识片段。</p>
+          </> : <>
+            <strong>知识库检索失败</strong>
+            <p role="alert">{error} 请点击“检索”重试。</p>
+          </>}
+        </div>
+      )}
+      {resultPage && resultPage.total > 0 && (
+        <div className="knowledge-search-pagination">
+          <span>第 {resultPage.page} / {totalPages} 页 · 当前显示 {(resultPage.page - 1) * resultPage.pageSize + 1}–{(resultPage.page - 1) * resultPage.pageSize + results.length} 条</span>
+          <div>
+            <button type="button" className="secondary-action" disabled={loading || resultPage.page <= 1} onClick={() => onPageChange(resultPage.page - 1)}>上一页</button>
+            <button type="button" className="secondary-action" disabled={loading || resultPage.page >= totalPages} onClick={() => onPageChange(resultPage.page + 1)}>下一页</button>
+          </div>
         </div>
       )}
     </section>

--- a/client/src/features/knowledge-base/types.ts
+++ b/client/src/features/knowledge-base/types.ts
@@ -6,6 +6,19 @@ export interface KnowledgeItem {
   source_block_ids?: string[];
   source_file?: string;
 }
+export type KnowledgeSearchMatchField = 'file_name' | 'title' | 'resume' | 'content';
+
+export interface KnowledgeBaseSearchResult {
+  document_id: string;
+  folder_id: string;
+  folder_name: string;
+  file_name: string;
+  item_id: string;
+  title: string;
+  resume: string;
+  snippet: string;
+  match_field: KnowledgeSearchMatchField;
+}
 
 export interface KnowledgeCandidateItem {
   id: string;

--- a/client/src/features/knowledge-base/types.ts
+++ b/client/src/features/knowledge-base/types.ts
@@ -20,6 +20,18 @@ export interface KnowledgeBaseSearchResult {
   match_field: KnowledgeSearchMatchField;
 }
 
+export interface KnowledgeBaseSearchRequest {
+  keyword: string;
+  page: number;
+}
+
+export interface KnowledgeBaseSearchPage {
+  items: KnowledgeBaseSearchResult[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
 export interface KnowledgeCandidateItem {
   id: string;
   title: string;

--- a/client/src/shared/types/ipc.ts
+++ b/client/src/shared/types/ipc.ts
@@ -1,7 +1,7 @@
 import type { AiHttpErrorPayload, ChatCompletionRequest, JsonCompletionRequest } from './ai';
 import type { DuplicateCheckWorkspacePatch, DuplicateCheckWorkspaceState, FileSelectionResult } from './bid';
 import type { ClientConfig, ConfigSaveResult, ImageModelTestResult, ModelInfoResult, ModelListResult, UpdateChannel } from './config';
-import type { KnowledgeAnalysisSnapshot, KnowledgeBaseEvent, KnowledgeBaseIndex, KnowledgeBaseIndexMutationResult, KnowledgeBaseMutationResult, KnowledgeBaseRetryDocumentResult, KnowledgeBaseStartMatchingResult, KnowledgeBaseUploadResult, KnowledgeDocument, KnowledgeFolder, KnowledgeItem } from '../../features/knowledge-base/types';
+import type { KnowledgeAnalysisSnapshot, KnowledgeBaseEvent, KnowledgeBaseIndex, KnowledgeBaseIndexMutationResult, KnowledgeBaseMutationResult, KnowledgeBaseSearchResult, KnowledgeBaseRetryDocumentResult, KnowledgeBaseStartMatchingResult, KnowledgeBaseUploadResult, KnowledgeDocument, KnowledgeFolder, KnowledgeItem } from '../../features/knowledge-base/types';
 import type { RejectionCheckWorkspacePatch, RejectionCheckWorkspaceState, RejectionDocumentRole } from '../../features/rejection-check/types';
 import type { BidAnalysisMode, BidAnalysisTaskState, BidSectionMode, ContentGenerationOptions, ContentGenerationPlanState, ContentGenerationProgressDetail, ContentGenerationRuntimeState, ContentGenerationSectionState, DetectedBidSection, GlobalFactGroupState, GlobalFactsMode, SaveOutlineRequest, SaveOutlineSelectionRequest, TechnicalPlanState, TechnicalPlanStep, TechnicalPlanWorkflowKind } from '../../features/technical-plan/types';
 import type { FeasibilityProjectInfo, FeasibilityReportState, FeasibilityReportStep, FeasibilitySaveOutlineRequest, FeasibilitySourceFile } from '../../features/feasibility-report/types';
@@ -629,6 +629,7 @@ export interface YibiaoBridge {
   };
   knowledgeBase: {
     list: () => Promise<KnowledgeBaseIndex>;
+    search: (keyword: string) => Promise<KnowledgeBaseSearchResult[]>;
     createFolder: (name: string) => Promise<KnowledgeFolder>;
     renameFolder: (folderId: string, name: string) => Promise<KnowledgeFolder>;
     reorderFolder: (draggedFolderId: string, targetFolderId: string, position: 'before' | 'after') => Promise<KnowledgeBaseIndexMutationResult>;

--- a/client/src/shared/types/ipc.ts
+++ b/client/src/shared/types/ipc.ts
@@ -1,7 +1,7 @@
 import type { AiHttpErrorPayload, ChatCompletionRequest, JsonCompletionRequest } from './ai';
 import type { DuplicateCheckWorkspacePatch, DuplicateCheckWorkspaceState, FileSelectionResult } from './bid';
 import type { ClientConfig, ConfigSaveResult, ImageModelTestResult, ModelInfoResult, ModelListResult, UpdateChannel } from './config';
-import type { KnowledgeAnalysisSnapshot, KnowledgeBaseEvent, KnowledgeBaseIndex, KnowledgeBaseIndexMutationResult, KnowledgeBaseMutationResult, KnowledgeBaseSearchResult, KnowledgeBaseRetryDocumentResult, KnowledgeBaseStartMatchingResult, KnowledgeBaseUploadResult, KnowledgeDocument, KnowledgeFolder, KnowledgeItem } from '../../features/knowledge-base/types';
+import type { KnowledgeAnalysisSnapshot, KnowledgeBaseEvent, KnowledgeBaseIndex, KnowledgeBaseIndexMutationResult, KnowledgeBaseMutationResult, KnowledgeBaseSearchRequest, KnowledgeBaseSearchPage, KnowledgeBaseRetryDocumentResult, KnowledgeBaseStartMatchingResult, KnowledgeBaseUploadResult, KnowledgeDocument, KnowledgeFolder, KnowledgeItem } from '../../features/knowledge-base/types';
 import type { RejectionCheckWorkspacePatch, RejectionCheckWorkspaceState, RejectionDocumentRole } from '../../features/rejection-check/types';
 import type { BidAnalysisMode, BidAnalysisTaskState, BidSectionMode, ContentGenerationOptions, ContentGenerationPlanState, ContentGenerationProgressDetail, ContentGenerationRuntimeState, ContentGenerationSectionState, DetectedBidSection, GlobalFactGroupState, GlobalFactsMode, SaveOutlineRequest, SaveOutlineSelectionRequest, TechnicalPlanState, TechnicalPlanStep, TechnicalPlanWorkflowKind } from '../../features/technical-plan/types';
 import type { FeasibilityProjectInfo, FeasibilityReportState, FeasibilityReportStep, FeasibilitySaveOutlineRequest, FeasibilitySourceFile } from '../../features/feasibility-report/types';
@@ -629,7 +629,7 @@ export interface YibiaoBridge {
   };
   knowledgeBase: {
     list: () => Promise<KnowledgeBaseIndex>;
-    search: (keyword: string) => Promise<KnowledgeBaseSearchResult[]>;
+    search: (request: KnowledgeBaseSearchRequest) => Promise<KnowledgeBaseSearchPage>;
     createFolder: (name: string) => Promise<KnowledgeFolder>;
     renameFolder: (folderId: string, name: string) => Promise<KnowledgeFolder>;
     reorderFolder: (draggedFolderId: string, targetFolderId: string, position: 'before' | 'after') => Promise<KnowledgeBaseIndexMutationResult>;

--- a/client/src/styles/feature-knowledge-base.css
+++ b/client/src/styles/feature-knowledge-base.css
@@ -53,6 +53,131 @@
   box-shadow: 0 10px 24px rgba(33, 116, 253, 0.16);
 }
 
+.knowledge-global-search {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid var(--yb-border-soft);
+  border-radius: var(--yb-radius-lg);
+  box-shadow: 0 10px 28px rgba(33, 116, 253, 0.08);
+}
+
+.knowledge-global-search > label {
+  color: var(--yb-text);
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.knowledge-global-search-controls {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto auto;
+  gap: 8px;
+}
+
+.knowledge-global-search-controls input {
+  min-width: 0;
+  height: 42px;
+  padding: 0 14px;
+  color: var(--yb-text);
+  font-size: 14px;
+  background: #ffffff;
+  border: 1px solid var(--yb-border-soft);
+  border-radius: var(--yb-radius-md);
+  outline: none;
+}
+
+.knowledge-global-search-controls input:focus {
+  border-color: rgba(33, 116, 253, 0.5);
+  box-shadow: var(--yb-focus-ring);
+}
+
+.knowledge-search-panel {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
+  flex: 1 1 0;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid var(--yb-border-soft);
+  border-radius: var(--yb-radius-lg);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.knowledge-search-result-list {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  min-height: 0;
+  overflow: auto;
+  padding: 12px;
+  scrollbar-gutter: stable;
+}
+
+.knowledge-search-result-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  background: var(--yb-bg);
+  border: 1px solid var(--yb-border-soft);
+  border-radius: var(--yb-radius-md);
+  transition: background var(--yb-duration-fast) ease, border-color var(--yb-duration-fast) ease, box-shadow var(--yb-duration-fast) ease;
+}
+
+.knowledge-search-result-card:hover {
+  background: #ffffff;
+  border-color: rgba(33, 116, 253, 0.2);
+  box-shadow: var(--yb-shadow-sm);
+}
+
+.knowledge-search-result-path,
+.knowledge-search-result-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.knowledge-search-result-path {
+  color: var(--yb-text-muted);
+  font-size: 12px;
+}
+
+.knowledge-search-result-path strong {
+  overflow: hidden;
+  max-width: 70ch;
+  color: var(--yb-primary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.knowledge-search-result-card h3,
+.knowledge-search-result-card p {
+  margin: 0;
+}
+
+.knowledge-search-result-card h3 {
+  color: var(--yb-text);
+  font-size: 16px;
+}
+
+.knowledge-search-result-card p {
+  color: var(--yb-text-muted);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.knowledge-search-result-actions .secondary-action,
+.knowledge-search-result-actions .knowledge-item-source-action {
+  min-height: 36px;
+}
+
+@media (max-width: 760px) {
+  .knowledge-global-search-controls {
+    grid-template-columns: 1fr;
+  }
+}
+
 .knowledge-create-folder-bar {
   display: flex;
   align-items: center;

--- a/client/src/styles/feature-knowledge-base.css
+++ b/client/src/styles/feature-knowledge-base.css
@@ -94,7 +94,7 @@
 
 .knowledge-search-panel {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr) auto;
   min-height: 0;
   flex: 1 1 0;
   overflow: hidden;
@@ -112,6 +112,23 @@
   overflow: auto;
   padding: 12px;
   scrollbar-gutter: stable;
+}
+
+.knowledge-search-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 12px;
+  border-top: 1px solid var(--yb-border-soft);
+  color: var(--yb-text-muted);
+  font-size: 13px;
+}
+
+.knowledge-search-pagination > div {
+  display: flex;
+  gap: 8px;
 }
 
 .knowledge-search-result-card {

--- a/client/开发说明.md
+++ b/client/开发说明.md
@@ -131,6 +131,8 @@ Renderer
 
 `taskService.cjs` 统一管理技术方案、标书查重和废标检查任务；三个业务组当前均为组内互斥。知识库是明确例外：`knowledgeBaseService.cjs` 按文档维护 preparation/matching 活动集合，并通过 `knowledge-base:event` 推送。Word 导出也有独立的进度事件。
 
+知识库全局检索使用 `knowledgeBase.search({ keyword, page })`，页码从 1 开始，返回 `{ items, total, page, pageSize }`，每页 100 条。`total` 与当前页在同一 SQLite 读事务中查询；数据减少导致页码越界时返回最后一个有效页。Renderer 使用返回页码和总数展示，翻页沿用已提交关键字，失败保留上次成功页，清空搜索使未完成请求失效。检索仍是 Main 同步子串扫描，分页不代表全文索引或后台线程查询。
+
 受管任务遵循以下流程：
 
 1. Main 创建 running 任务并持久化初始状态。


### PR DESCRIPTION
## 关联 Issue

Closes #116

## 修改背景

知识库目前只能按照文件夹和文档逐层浏览，无法通过关键字跨全部知识库查找历史资料。

当用户维护了多个文件夹和大量投标文档时，需要先手动定位文件夹，再打开文档查看知识条目，查找可复用内容的效率较低。

本 PR 增加知识库全局关键字检索能力。

## 修改内容

### 1. 增加知识库全局检索接口

新增 `knowledge-base:search` IPC 通道，并贯通以下链路：

```text
KnowledgeBasePage
  → window.yibiao.knowledgeBase.search()
  → preload
  → knowledgeBaseIpc
  → knowledgeBaseService
  → knowledgeBaseStore
  → SQLite
 ```

 ### 2. 增加 SQLite 全局检索

 在 knowledgeBaseStore 中增加全局检索方法，跨所有文件夹和文档检索已完成的知识条目。

 检索范围包括：

 - 知识条目标题 title
 - 知识条目摘要 resume
 - 知识条目正文 content
 - 所属文档文件名 file_name

 检索规则：

 - 只检索 status = 'success' 的文档
 - 空关键字直接返回空结果
 - 结果最多返回 100 条
 - 标题命中优先于摘要、正文和文件名命中
 - 同一优先级下按照文档更新时间、条目顺序稳定排序
 - 自动生成命中内容附近的文本片段
 - 不新增数据库表、不修改现有数据库 schema、不需要 migration

 ### 3. 增加知识库页面检索入口

 在「知识库 → 文档知识库」页面增加「全库检索」区域，支持：

 - 输入关键字并提交检索
 - 显示检索中状态
 - 显示检索结果数量
 - 显示所属文件夹
 - 显示所属文档
 - 显示知识条目标题
 - 显示命中片段
 - 点击「打开知识条目」进入对应文档的知识条目查看页面
 - 点击「返回文件夹」恢复原有文件夹和文档列表
 - 无匹配结果时显示空结果提示

 ### 4. 增加请求过期保护

 为搜索请求增加请求编号。

 当用户快速重复发起检索或清空搜索时，旧请求返回结果不会覆盖当前搜索状态。

 ### 5. 增加检索行为测试

 新增：

 ```text
client/electron/services/knowledgeBaseStore.search.test.cjs
 ```

 覆盖：

 - 文件名命中
 - 跨多个文档检索
 - 标题命中优先排序
 - 摘要命中
 - 未完成文档不参与检索
 - 空关键字不触发查询
 - 检索结果片段生成

 修改文件

 ```text
client/electron/ipc/index.cjs
client/electron/ipc/knowledgeBaseIpc.cjs
client/electron/preload.cjs
client/electron/services/knowledgeBaseService.cjs
client/electron/services/knowledgeBaseStore.cjs
client/electron/services/knowledgeBaseStore.search.test.cjs
client/src/features/knowledge-base/pages/KnowledgeBasePage.tsx
client/src/features/knowledge-base/types.ts
client/src/shared/types/ipc.ts
client/src/styles/feature-knowledge-base.css
 ```

 兼容性说明

 - 不修改现有数据库表结构
 - 不增加数据库 migration
 - 不改变已有知识库上传、解析、匹配、删除和查看逻辑
 - 不改变技术方案引用知识库的逻辑
 - 不引入新的依赖
 - 不新增远程搜索或向量检索
 - 检索结果不落库，始终从当前 SQLite 数据实时查询
 - 仍然遵循 Renderer 不直接访问 SQLite 和 Node API 的架构约束

 验证方式

 ### 自动化测试

 使用 Electron 自带 Node 环境运行，避免 better-sqlite3 与普通 Node ABI 不匹配：

 ```powershell
cd client
$env:ELECTRON_RUN_AS_NODE=1
.\node_modules\electron\dist\electron.exe --test electron\services\*.test.cjs electron\ipc\*.test.cjs
 ```

 结果：

 ```text
tests 20
pass 20
fail 0
 ```

 其中新增知识库检索测试：

 ```text
3 passed
0 failed
 ```

 ### Electron 原生 SQLite 验证

 ```powershell
cd client
npm run smoke:electron-native
 ```

 结果：

 ```text
better-sqlite3 loaded and queried successfully.
 ```

 ### 客户端构建

 ```powershell
cd client
npm run build
 ```

 结果：

 ```text
tsc --noEmit 通过
vite build 通过
 ```

 项目原有的 chunk 体积警告不影响构建结果。

 ### CommonJS 语法检查

 ```powershell
cd client
node --check electron/services/knowledgeBaseStore.cjs
node --check electron/services/knowledgeBaseService.cjs
node --check electron/services/knowledgeBaseStore.search.test.cjs
node --check electron/ipc/knowledgeBaseIpc.cjs
node --check electron/ipc/index.cjs
node --check electron/preload.cjs
 ```

 全部通过。

 ### 手动验证路径

 ```text
启动客户端
→ 知识库
→ 文档知识库
→ 全库检索
→ 输入已有知识库中的关键字
→ 点击“检索”
 ```

 已验证：

 - 检索入口正常显示
 - 空关键字不会触发查询
 - 有匹配结果时显示文件夹、文档、知识条目和命中片段
 - 点击「打开知识条目」可以进入对应文档
 - 不存在关键字时显示「没有找到相关知识」
 - 点击「返回文件夹」后恢复原有文件夹/文档列表
 - 空结果和正常结果页面布局均正常
 - 未完成文档不会出现在检索结果中

 Review 重点

 请重点 review 以下内容：

 1. 全局检索结果是否满足知识库使用场景
 2. 当前检索字段是否合适
 3. 仅检索已完成文档的规则是否符合预期
 4. 标题、摘要、正文和文件名的结果排序是否合理
 5. 搜索结果进入对应知识条目查看页面的交互是否符合预期
 


 ## 测试截图

知识库截图
<img width="1920" height="975" alt="b547694a89ae24b649103f592f8e9ef3" src="https://github.com/user-attachments/assets/9499f3db-ac68-403d-9246-16a9c26ec5de" />

知识库搜索截图
<img width="1920" height="975" alt="a1e418d5e5d5cca7d739dde62c8d954d" src="https://github.com/user-attachments/assets/eae31df4-9c66-445f-94ae-7d9d68b35c53" />



