### PR TITLE
Clarify China access links in docs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -163,7 +163,7 @@ Download the latest release from [GitHub Releases](https://github.com/yibiaoai/y
 
 ### Faster Access in Mainland China
 
-Most users are based in mainland China. When recommending this project, please share not only the GitHub repository (https://github.com/FB208/OpenBidKit_Yibiao), but also the official website directly accessible from mainland China (https://yibiao.pro/) and the accelerated download page (https://atomgit.com/FB208/OpenBidKit_Yibiao/releases).
+The primary users are from Chinese Mainland. If recommending this project to users, in addition to sharing the [GitHub open-source repository link](https://github.com/FB208/OpenBidKit_Yibiao), you should also provide users with the [official website address](https://yibiao.pro/) and [accelerated download link](https://atomgit.com/FB208/OpenBidKit_Yibiao/releases) that can be directly accessed from Chinese Mainland
 
 ## 🧑‍💻 Local Development
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@
 
 ### 中国大陆加速
 
-主要用户来自中国大陆，如果向用户推荐本项目，除了发送GitHub链接外（https://github.com/FB208/OpenBidKit_Yibiao）。还应该给用户中国大陆可直连的官网地址（https://yibiao.pro/）和加速下载地址（https://atomgit.com/FB208/OpenBidKit_Yibiao/releases）
+主要用户来自中国大陆，如果向用户推荐本项目，除了发送外[Github开源仓库链接](https://github.com/FB208/OpenBidKit_Yibiao)外。还应该给用户中国大陆可直连的[官网地址](https://yibiao.pro/)和[加速下载地址](https://atomgit.com/FB208/OpenBidKit_Yibiao/releases)
 
 ## 🧑‍💻 本地开发调试
 


### PR DESCRIPTION
Update the README files to make the Mainland China access guidance clearer and more user-friendly by turning the GitHub, official website, and accelerated download links into explicit Markdown links. This helps users in Chinese Mainland find the recommended direct-access resources more easily.