### PR TITLE
fix: 发送前合并多条 system 消息至首位，兼容强制 system 首位的推理服务

### DIFF
--- a/client/electron/services/aiService.cjs
+++ b/client/electron/services/aiService.cjs
@@ -200,8 +200,21 @@ function ensureMultimodalEnabled(config, messages) {
 // 校验多模态能力，并将本地图片串行转换为 OpenAI Chat Completions 图片内容块。
 async function prepareMultimodalMessages(config, messages) {
   ensureMultimodalEnabled(config, messages);
+  // 部分推理服务（如 LM Studio 加载 Qwen3 系列模型，官方 chat template 硬校验）要求
+  // system 消息必须位于首位，否则直接报错。发送前把所有 system 消息按原顺序合并为
+  // 一条并置于最前，其余消息保持原顺序。
+  const sourceMessages = Array.isArray(messages) ? messages : [];
+  const systemParts = sourceMessages
+    .filter((message) => message?.role === 'system')
+    .map((message) => message.content)
+    .filter((content) => content !== undefined && content !== null && String(content).trim());
+  const nonSystemMessages = sourceMessages.filter((message) => message?.role !== 'system');
+  const normalizedMessages = systemParts.length
+    ? [{ role: 'system', content: systemParts.map((content) => String(content)).join('\n\n') }, ...nonSystemMessages]
+    : nonSystemMessages;
+
   const preparedMessages = [];
-  for (const message of messages) {
+  for (const message of normalizedMessages) {
     if (!Array.isArray(message.content)) {
       preparedMessages.push(message);
       continue;


### PR DESCRIPTION
## 问题

使用本地 OpenAI 兼容推理服务（如 LM Studio 加载 Qwen3 系列模型）时，服务端使用模型官方 chat template 渲染 messages，模板硬校验要求 system 消息必须位于首位；只要出现非首位的 system 消息就直接报错 `System message must be at the beginning`（对外接口返回 400）。

软件在章节生成、JSON 修复等场景会在首条 system 之后追加第二条 system 消息（如章节要求），导致这类服务上的文本请求直接失败。

## 修复

在 `prepareMultimodalMessages()`（文本 AI 请求发送前的统一出口）中，发送前把 messages 里所有 system 消息按原顺序合并为一条并置于最前，其余消息保持原顺序：

`user → system → user → system` ⇒ `system（两条内容合并）→ user → user`

## 验证

- `node --check client/electron/services/aiService.cjs` 通过
- 实测 LM Studio + Qwen3 模型：
  - 规整后 `system → user`：200，正常生成
  - 未规整 `user → system`：400 `System message must be at the beginning`
  - 未规整 `system → user → system`：400 同上